### PR TITLE
`ConcurrentOrderedBag` is defined.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [orxfun]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "orx-concurrent-ordered-bag"
+version = "1.0.0"
+edition = "2021"
+authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
+description = "An efficient, convenient and lightweight grow-only concurrent data structure allowing high performance and ordered concurrent collection."
+license = "MIT"
+repository = "https://github.com/orxfun/orx-ordered-concurrent-bag/"
+keywords = [
+    "concurrency",
+    "parallelization",
+    "data-structures",
+    "atomic",
+    "lock-free",
+]
+categories = ["data-structures", "concurrency", "rust-patterns"]
+
+[dependencies]
+orx-fixed-vec = "2.8"
+orx-pinned-concurrent-col = "1.1"
+orx-pinned-vec = "2.8"
+orx-split-vec = "2.9"
+
+[dev-dependencies]
+orx-concurrent-iter = "1.1"
+test-case = "3.3.1"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,253 @@
-# orx-concurrent-ordered-collection
-placeholder
+# orx-concurrent-ordered-bag
+
+[![orx-concurrent-ordered-bag crate](https://img.shields.io/crates/v/orx-concurrent-ordered-bag.svg)](https://crates.io/crates/orx-concurrent-ordered-bag)
+[![orx-concurrent-ordered-bag documentation](https://docs.rs/orx-concurrent-ordered-bag/badge.svg)](https://docs.rs/orx-concurrent-ordered-bag)
+
+An efficient, convenient and lightweight grow-only concurrent data structure allowing high performance and ordered concurrent collection.
+
+* **convenient**: `ConcurrentBag` can safely be shared among threads simply as a shared reference. It is a [`PinnedConcurrentCol`](https://crates.io/crates/orx-pinned-concurrent-col) with a special concurrent state implementation. Underlying [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) and concurrent bag can be converted back and forth to each other. Further, as you may see in the parallel map example, it enables efficient parallel methods with possibly the most convenient and simple implementation.
+* **efficient**: `ConcurrentBag` is a lock free structure making use of a few atomic primitives, this leads to high performance concurrent growth while enabling to collect the results in the desired order.
+
+## Comparison to `ConcurrentBag`
+
+Note that [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-vec) is a similar structure with the following differences.
+
+||`ConcurrentBag`|`ConcurrentOrderedBag`|
+|---|---|---|
+| Ordering | Cannot guarantee that the elements are in a desired order, the order of the collected elements depends on the time different threads push elements. | Allows to write to particular position enabling concurrently collecting elements in a desired order (fits very well to a parallel map). |
+| Safety of Growth | ConcurrentBag can be filled with safe `push` and `extend` calls. It makes sure that each position will be written to exactly once and there exists no race condition. | ConcurrentOrderedBag allows for more freedom by allowing to write to arbitrary positions of the collection. However, focusing on efficiency, it does not keep track of the filled positions. It is the caller's responsibility that every position is written only once and bag does not contain any gaps. Therefore, growth happens through unsafe `set_value`, `set_values` and `set_n_values` methods. However, as it will be clear in the examples that it is conveniently possible to achieve this guarantees with the help of [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter). |
+| Safety of `into_inner` | Into inner call cannot fail. Underlying pinned vector of a ConcurrentBag is always gap-free and valid; therefore, the bag can be converted into the underlying vector without care at any point in time. | Due to the above-mentioned reasons, ConcurrentOrderedBag might contain gaps. `into_inner` call provides some useful metrics such as number of elements pushed and maximum index of the vector; however, it cannot guarantee that the bag is gap-free. Therefore, the caller is required to take responsibility to unwrap the pinned vec or not through an unsafe call. |
+
+## Safety Requirements
+
+As the comparison reveals, `ConcurrentBag` is much safer to use than `ConcurrentOrderedBag`, which could be the first choice if the order of collected elements does not matter. On the other hand, required safety guarantees fortunately are not too difficult to satisfy. ConcurrentOrderedBag can safely be used provided that the following two conditions are satisfied:
+* Each position is written exactly once, so that there exists no race condition.
+* At the point where `into_inner` is called (not necessarily always), the bag must not contain any gaps.
+  * Let `m` be the maximum index of the position that we write an element to.
+  * The bag assumes that the length of the vector is equal to `m + 1`.
+  * Then, it expects that exactly `m + 1` elements are written to the bag.
+  * If the first condition was satisfied; then, this condition is sufficient to conclude that the bag can be converted to the underlying vector of `m + 1` elements.
+
+## Examples
+
+Safety guarantees to push to the bag with a shared reference makes it easy to share the bag among threads. However, the caller is required to make sure that the collection does not contain gaps and each position is written exactly once.
+
+### Manual Example
+
+In the following example, we split computation among two threads: the first thread processes inputs with even indices, and the second with odd indices. This provides the required guarantee mentioned above.
+
+```rust
+use orx_concurrent_ordered_bag::*;
+
+let n = 1024;
+
+let evens_odds = ConcurrentOrderedBag::new();
+
+// just take a reference and share among threads
+let bag = &evens_odds;
+
+std::thread::scope(|s| {
+    s.spawn(move || {
+        for i in (0..n).filter(|x| x % 2 == 0) {
+            unsafe { bag.set_value(i, i as i32) };
+        }
+    });
+
+    s.spawn(move || {
+        for i in (0..n).filter(|x| x % 2 == 1) {
+            unsafe { bag.set_value(i, -(i as i32)) };
+        }
+    });
+});
+
+let vec = unsafe { evens_odds.into_inner().unwrap_only_if_counts_match() };
+assert_eq!(vec.len(), n);
+for i in 0..n {
+    if i % 2 == 0 {
+        assert_eq!(vec[i], i as i32);
+    } else {
+        assert_eq!(vec[i], -(i as i32));
+    }
+}
+```
+
+Note that as long as no-gap and write-only-once guarantees are satisfied, `ConcurrentOrderedBag` is very flexible in the order of writes. They can simply happen in arbitrary order. Consider the following instance for instance. We spawn a thread just two write to the end of the collection, and then spawn a bunch of other threads to fill the beginning of the collection. This just works without any locks or waits.
+
+```rust
+use orx_concurrent_ordered_bag::*;
+
+let n = 1024;
+let num_additional_threads = 4;
+
+let bag = ConcurrentOrderedBag::new();
+let con_bag = &bag;
+
+std::thread::scope(|s| {
+    s.spawn(move || {
+        // start writing to the end
+        unsafe { con_bag.set_value(n - 1, 42) };
+    });
+
+    for thread in 0..num_additional_threads {
+        s.spawn(move || {
+            // then fill the rest concurrently from the beginning
+            for i in (0..(n - 1)).filter(|i| i % num_additional_threads == thread) {
+                unsafe { con_bag.set_value(i, i as i32) };
+            }
+        });
+    }
+});
+
+let vec = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
+assert_eq!(vec.len(), n);
+for i in 0..(n - 1) {
+    assert_eq!(vec[i], i as i32);
+}
+assert_eq!(vec[n - 1], 42);
+```
+
+These examples represent cases where the work can be trivially split among threads while providing the safety requirements. However, it requires special care and correctness. This complexity can significantly be avoided by pairing the `ConcurrentOrderedBag` with a [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter) on the input side.
+
+### Parallel Map with `ConcurrentIter`
+
+Parallel map operation is one of the cases where we would care about the order of the collected elements, and hence, `ConcurrentBag` would not suffice. On the other hand, an efficient implementation can be achieved with `ConcurrentOrderedBag` and `ConcurrentIter`. Further, it might **possibly be the most convenient parallel map** implementation that is almost identical to a single-threaded map implementation.
+
+```rust
+use orx_concurrent_ordered_bag::*;
+use orx_concurrent_iter::*;
+
+fn parallel_map<In, Out, Map, Inputs>(
+    num_threads: usize,
+    inputs: Inputs,
+    map: &Map,
+) -> ConcurrentOrderedBag<Out>
+where
+    Inputs: ConcurrentIter<Item = In>,
+    Map: Fn(In) -> Out + Send + Sync,
+    Out: Send + Sync,
+{
+    let outputs = ConcurrentOrderedBag::new();
+    let inputs = &inputs;
+    let out = &outputs;
+    std::thread::scope(|s| {
+        for _ in 0..num_threads {
+            s.spawn(|| {
+                while let Some(next) = inputs.next_id_and_value() {
+                    unsafe { out.set_value(next.idx, map(next.value)) };
+                }
+            });
+        }
+    });
+    outputs
+}
+
+let len = 2465;
+let vec: Vec<_> = (0..len).map(|x| x.to_string()).collect();
+
+let bag = parallel_map(4, vec.into_con_iter(), &|x| x.to_string().len());
+let output = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
+
+assert_eq!(output.len(), len);
+for (i, value) in output.iter().enumerate() {
+    assert_eq!(value, &i.to_string().len());
+}
+```
+
+As you may see, we are not required to share the work manually, we simply use a `while let Some` loop. The work is pulled by threads from the iterator. This both leads to an efficient implementation especially in cases of heterogeneous work loads of each task and automatically provides the safety requirements.
+
+
+### Parallel Map with `ExactSizeConcurrentIter`
+
+A further performance improvement to the parallel map implementation above is to distribute the tasks among the threads in chunks. The aim of this approach is to avoid false sharing, you may see further details [here](https://docs.rs/orx-concurrent-bag/latest/orx_concurrent_bag/#section-performance-notes). This can be achieved by pairing an [`ExactSizeConcurrentIter`](https://docs.rs/orx-concurrent-iter/latest/orx_concurrent_iter/trait.ExactSizeConcurrentIter.html) rather than a ConcurrentIter with the `set_values` method of the `ConcurrentOrderedBag`.
+
+```rust
+use orx_concurrent_ordered_bag::*;
+use orx_concurrent_iter::*;
+
+fn parallel_map<In, Out, Map, Inputs>(
+    num_threads: usize,
+    inputs: Inputs,
+    map: &Map,
+    chunk_size: usize,
+) -> ConcurrentOrderedBag<Out>
+where
+    Inputs: ExactSizeConcurrentIter<Item = In>,
+    Map: Fn(In) -> Out + Send + Sync,
+    Out: Send + Sync,
+{
+    let outputs = ConcurrentOrderedBag::new();
+    let inputs = &inputs;
+    let out = &outputs;
+    std::thread::scope(|s| {
+        for _ in 0..num_threads {
+            s.spawn(|| {
+                while let Some(next) = inputs.next_exact_chunk(chunk_size) {
+                    unsafe { out.set_values(next.begin_idx(), next.values().map(map)) };
+                }
+            });
+        }
+    });
+    outputs
+}
+
+let len = 2465;
+let vec: Vec<_> = (0..len).map(|x| x.to_string()).collect();
+let bag = parallel_map(4, vec.into_con_iter(), &|x| x.to_string().len(), 64);
+let output = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
+for (i, value) in output.iter().enumerate() {
+    assert_eq!(value, &i.to_string().len());
+}
+```
+
+### Construction
+
+`ConcurrentOrderedBag` can be constructed by wrapping any pinned vector; i.e., `ConcurrentOrderedBag<T>` implements `From<P: PinnedVec<T>>`. Likewise, a concurrent vector can be unwrapped without any allocation to the underlying pinned vector with `into_inner` method, provided that the safety requirements are satisfied.
+
+Further, there exist `with_` methods to directly construct the concurrent bag with common pinned vector implementations.
+
+```rust
+use orx_concurrent_ordered_bag::*;
+
+// default pinned vector -> SplitVec<T, Doubling>
+let bag: ConcurrentOrderedBag<char> = ConcurrentOrderedBag::new();
+let bag: ConcurrentOrderedBag<char> = Default::default();
+let bag: ConcurrentOrderedBag<char> = ConcurrentOrderedBag::with_doubling_growth();
+let bag: ConcurrentOrderedBag<char, SplitVec<char, Doubling>> = ConcurrentOrderedBag::with_doubling_growth();
+
+let bag: ConcurrentOrderedBag<char> = SplitVec::new().into();
+let bag: ConcurrentOrderedBag<char, SplitVec<char, Doubling>> = SplitVec::new().into();
+
+// SplitVec with [Linear](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Linear.html) growth
+// each fragment will have capacity 2^10 = 1024
+// and the split vector can grow up to 32 fragments
+let bag: ConcurrentOrderedBag<char, SplitVec<char, Linear>> = ConcurrentOrderedBag::with_linear_growth(10, 32);
+let bag: ConcurrentOrderedBag<char, SplitVec<char, Linear>> = SplitVec::with_linear_growth_and_fragments_capacity(10, 32).into();
+
+// [FixedVec](https://docs.rs/orx-fixed-vec/latest/orx_fixed_vec/) with fixed capacity.
+// Fixed vector cannot grow; hence, pushing the 1025-th element to this bag will cause a panic!
+let bag: ConcurrentOrderedBag<char, FixedVec<char>> = ConcurrentOrderedBag::with_fixed_capacity(1024);
+let bag: ConcurrentOrderedBag<char, FixedVec<char>> = FixedVec::new(1024).into();
+```
+
+Of course, the pinned vector to be wrapped does not need to be empty.
+
+```rust
+use orx_concurrent_ordered_bag::*;
+
+let split_vec: SplitVec<i32> = (0..1024).collect();
+let bag: ConcurrentOrderedBag<_> = split_vec.into();
+```
+
+## Concurrent State and Properties
+
+The concurrent state is modeled simply by an atomic capacity. Combination of this state and `PinnedConcurrentCol` leads to the following properties:
+* Writing to a position of the collection does not block other writes, multiple writes can happen concurrently.
+* Caller is required to guarantee that each position is written exactly once.
+* ⟹ caller is responsible to avoid write & write race conditions.
+* Only one growth can happen at a given time.
+* Reading is only possible after converting the bag into the underlying `PinnedVec`.
+* ⟹ no read & write race condition exists.
+
+## License
+
+This library is licensed under MIT license. See LICENSE for details.

--- a/src/bag.rs
+++ b/src/bag.rs
@@ -1,0 +1,403 @@
+use crate::{failures::IntoInnerResult, state::ConcurrentOrderedBagState};
+use orx_pinned_concurrent_col::PinnedConcurrentCol;
+use orx_pinned_vec::PinnedVec;
+use orx_split_vec::{Doubling, SplitVec};
+use std::{
+    cmp::Ordering,
+    ops::{Deref, DerefMut},
+};
+
+/// An efficient, convenient and lightweight grow-only concurrent data structure allowing high performance and ordered concurrent collection.
+///
+/// * **convenient**: `ConcurrentBag` can safely be shared among threads simply as a shared reference. It is a [`PinnedConcurrentCol`](https://crates.io/crates/orx-pinned-concurrent-col) with a special concurrent state implementation. Underlying [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) and concurrent bag can be converted back and forth to each other. Further, as you may see in the parallel map example, it enables efficient parallel methods with possibly the most convenient and simple implementation.
+/// * **efficient**: `ConcurrentBag` is a lock free structure making use of a few atomic primitives, this leads to high performance concurrent growth while enabling to collect the results in the desired order.
+///
+/// ## Safety Requirements
+///
+/// As the comparison reveals, `ConcurrentBag` is much safer to use than `ConcurrentOrderedBag`, which could be the first choice if the order of collected elements does not matter. On the other hand, required safety guarantees fortunately are not too difficult to satisfy. ConcurrentOrderedBag can safely be used provided that the following two conditions are satisfied:
+/// * Each position is written exactly once, so that there exists no race condition.
+/// * At the point where `into_inner` is called (not necessarily always), the bag must not contain any gaps.
+///   * Let `m` be the maximum index of the position that we write an element to.
+///   * The bag assumes that the length of the vector is equal to `m + 1`.
+///   * Then, it expects that exactly `m + 1` elements are written to the bag.
+///   * If the first condition was satisfied; then, this condition is sufficient to conclude that the bag can be converted to the underlying vector of `m + 1` elements.
+///
+/// ## Examples
+///
+/// Safety guarantees to push to the bag with a shared reference makes it easy to share the bag among threads. However, the caller is required to make sure that the collection does not contain gaps and each position is written exactly once.
+///
+/// ### Manual Example
+///
+/// In the following example, we split computation among two threads: the first thread processes inputs with even indices, and the second with odd indices. This provides the required guarantee mentioned above.
+///
+/// ```rust
+/// use orx_concurrent_ordered_bag::*;
+///
+/// let n = 1024;
+///
+/// let evens_odds = ConcurrentOrderedBag::new();
+///
+/// // just take a reference and share among threads
+/// let bag = &evens_odds;
+///
+/// std::thread::scope(|s| {
+///     s.spawn(move || {
+///         for i in (0..n).filter(|x| x % 2 == 0) {
+///             unsafe { bag.set_value(i, i as i32) };
+///         }
+///     });
+///
+///     s.spawn(move || {
+///         for i in (0..n).filter(|x| x % 2 == 1) {
+///             unsafe { bag.set_value(i, -(i as i32)) };
+///         }
+///     });
+/// });
+///
+/// let vec = unsafe { evens_odds.into_inner().unwrap_only_if_counts_match() };
+/// assert_eq!(vec.len(), n);
+/// for i in 0..n {
+///     if i % 2 == 0 {
+///         assert_eq!(vec[i], i as i32);
+///     } else {
+///         assert_eq!(vec[i], -(i as i32));
+///     }
+/// }
+/// ```
+///
+/// Note that as long as no-gap and write-only-once guarantees are satisfied, `ConcurrentOrderedBag` is very flexible in the order of writes. They can simply happen in arbitrary order. Consider the following instance for instance. We spawn a thread just two write to the end of the collection, and then spawn a bunch of other threads to fill the beginning of the collection. This just works without any locks or waits.
+///
+/// ```rust
+/// use orx_concurrent_ordered_bag::*;
+///
+/// let n = 1024;
+/// let num_additional_threads = 4;
+///
+/// let bag = ConcurrentOrderedBag::new();
+/// let con_bag = &bag;
+///
+/// std::thread::scope(|s| {
+///     s.spawn(move || {
+///         // start writing to the end
+///         unsafe { con_bag.set_value(n - 1, 42) };
+///     });
+///
+///     for thread in 0..num_additional_threads {
+///         s.spawn(move || {
+///             // then fill the rest concurrently from the beginning
+///             for i in (0..(n - 1)).filter(|i| i % num_additional_threads == thread) {
+///                 unsafe { con_bag.set_value(i, i as i32) };
+///             }
+///         });
+///     }
+/// });
+///
+/// let vec = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
+/// assert_eq!(vec.len(), n);
+/// for i in 0..(n - 1) {
+///     assert_eq!(vec[i], i as i32);
+/// }
+/// assert_eq!(vec[n - 1], 42);
+/// ```
+///
+/// These examples represent cases where the work can be trivially split among threads while providing the safety requirements. However, it requires special care and correctness. This complexity can significantly be avoided by pairing the `ConcurrentOrderedBag` with a [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter) on the input side.
+///
+/// ### Parallel Map with `ConcurrentIter`
+///
+/// Parallel map operation is one of the cases where we would care about the order of the collected elements, and hence, `ConcurrentBag` would not suffice. On the other hand, an efficient implementation can be achieved with `ConcurrentOrderedBag` and `ConcurrentIter`. Further, it might **possibly be the most convenient parallel map** implementation that is almost identical to a single-threaded map implementation.
+///
+/// ```rust
+/// use orx_concurrent_ordered_bag::*;
+/// use orx_concurrent_iter::*;
+///
+/// fn parallel_map<In, Out, Map, Inputs>(
+///     num_threads: usize,
+///     inputs: Inputs,
+///     map: &Map,
+/// ) -> ConcurrentOrderedBag<Out>
+/// where
+///     Inputs: ConcurrentIter<Item = In>,
+///     Map: Fn(In) -> Out + Send + Sync,
+///     Out: Send + Sync,
+/// {
+///     let outputs = ConcurrentOrderedBag::new();
+///     let inputs = &inputs;
+///     let out = &outputs;
+///     std::thread::scope(|s| {
+///         for _ in 0..num_threads {
+///             s.spawn(|| {
+///                 while let Some(next) = inputs.next_id_and_value() {
+///                     unsafe { out.set_value(next.idx, map(next.value)) };
+///                 }
+///             });
+///         }
+///     });
+///     outputs
+/// }
+///
+/// let len = 2465;
+/// let vec: Vec<_> = (0..len).map(|x| x.to_string()).collect();
+///
+/// let bag = parallel_map(4, vec.into_con_iter(), &|x| x.to_string().len());
+/// let output = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
+///
+/// assert_eq!(output.len(), len);
+/// for (i, value) in output.iter().enumerate() {
+///     assert_eq!(value, &i.to_string().len());
+/// }
+/// ```
+///
+/// As you may see, we are not required to share the work manually, we simply use a `while let Some` loop. The work is pulled by threads from the iterator. This both leads to an efficient implementation especially in cases of heterogeneous work loads of each task and automatically provides the safety requirements.
+///
+///
+/// ### Parallel Map with `ExactSizeConcurrentIter`
+///
+/// A further performance improvement to the parallel map implementation above is to distribute the tasks among the threads in chunks. The aim of this approach is to avoid false sharing, you may see further details [here](https://docs.rs/orx-concurrent-bag/latest/orx_concurrent_bag/#section-performance-notes). This can be achieved by pairing an [`ExactSizeConcurrentIter`](https://docs.rs/orx-concurrent-iter/latest/orx_concurrent_iter/trait.ExactSizeConcurrentIter.html) rather than a ConcurrentIter with the `set_values` method of the `ConcurrentOrderedBag`.
+///
+/// ```rust
+/// use orx_concurrent_ordered_bag::*;
+/// use orx_concurrent_iter::*;
+///
+/// fn parallel_map<In, Out, Map, Inputs>(
+///     num_threads: usize,
+///     inputs: Inputs,
+///     map: &Map,
+///     chunk_size: usize,
+/// ) -> ConcurrentOrderedBag<Out>
+/// where
+///     Inputs: ExactSizeConcurrentIter<Item = In>,
+///     Map: Fn(In) -> Out + Send + Sync,
+///     Out: Send + Sync,
+/// {
+///     let outputs = ConcurrentOrderedBag::new();
+///     let inputs = &inputs;
+///     let out = &outputs;
+///     std::thread::scope(|s| {
+///         for _ in 0..num_threads {
+///             s.spawn(|| {
+///                 while let Some(next) = inputs.next_exact_chunk(chunk_size) {
+///                     unsafe { out.set_values(next.begin_idx(), next.values().map(map)) };
+///                 }
+///             });
+///         }
+///     });
+///     outputs
+/// }
+///
+/// let len = 2465;
+/// let vec: Vec<_> = (0..len).map(|x| x.to_string()).collect();
+/// let bag = parallel_map(4, vec.into_con_iter(), &|x| x.to_string().len(), 64);
+/// let output = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
+/// for (i, value) in output.iter().enumerate() {
+///     assert_eq!(value, &i.to_string().len());
+/// }
+/// ```
+///
+/// ### Construction
+///
+/// `ConcurrentOrderedBag` can be constructed by wrapping any pinned vector; i.e., `ConcurrentOrderedBag<T>` implements `From<P: PinnedVec<T>>`. Likewise, a concurrent vector can be unwrapped without any allocation to the underlying pinned vector with `into_inner` method, provided that the safety requirements are satisfied.
+///
+/// Further, there exist `with_` methods to directly construct the concurrent bag with common pinned vector implementations.
+///
+/// ```rust
+/// use orx_concurrent_ordered_bag::*;
+///
+/// // default pinned vector -> SplitVec<T, Doubling>
+/// let bag: ConcurrentOrderedBag<char> = ConcurrentOrderedBag::new();
+/// let bag: ConcurrentOrderedBag<char> = Default::default();
+/// let bag: ConcurrentOrderedBag<char> = ConcurrentOrderedBag::with_doubling_growth();
+/// let bag: ConcurrentOrderedBag<char, SplitVec<char, Doubling>> = ConcurrentOrderedBag::with_doubling_growth();
+///
+/// let bag: ConcurrentOrderedBag<char> = SplitVec::new().into();
+/// let bag: ConcurrentOrderedBag<char, SplitVec<char, Doubling>> = SplitVec::new().into();
+///
+/// // SplitVec with [Linear](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Linear.html) growth
+/// // each fragment will have capacity 2^10 = 1024
+/// // and the split vector can grow up to 32 fragments
+/// let bag: ConcurrentOrderedBag<char, SplitVec<char, Linear>> = ConcurrentOrderedBag::with_linear_growth(10, 32);
+/// let bag: ConcurrentOrderedBag<char, SplitVec<char, Linear>> = SplitVec::with_linear_growth_and_fragments_capacity(10, 32).into();
+///
+/// // [FixedVec](https://docs.rs/orx-fixed-vec/latest/orx_fixed_vec/) with fixed capacity.
+/// // Fixed vector cannot grow; hence, pushing the 1025-th element to this bag will cause a panic!
+/// let bag: ConcurrentOrderedBag<char, FixedVec<char>> = ConcurrentOrderedBag::with_fixed_capacity(1024);
+/// let bag: ConcurrentOrderedBag<char, FixedVec<char>> = FixedVec::new(1024).into();
+/// ```
+///
+/// Of course, the pinned vector to be wrapped does not need to be empty.
+///
+/// ```rust
+/// use orx_concurrent_ordered_bag::*;
+///
+/// let split_vec: SplitVec<i32> = (0..1024).collect();
+/// let bag: ConcurrentOrderedBag<_> = split_vec.into();
+/// ```
+///
+/// ## Concurrent State and Properties
+///
+/// The concurrent state is modeled simply by an atomic capacity. Combination of this state and `PinnedConcurrentCol` leads to the following properties:
+/// * Writing to a position of the collection does not block other writes, multiple writes can happen concurrently.
+/// * Caller is required to guarantee that each position is written exactly once.
+/// * ⟹ caller is responsible to avoid write & write race conditions.
+/// * Only one growth can happen at a given time.
+/// * Reading is only possible after converting the bag into the underlying `PinnedVec`.
+/// * ⟹ no read & write race condition exists.
+pub struct ConcurrentOrderedBag<T, P = SplitVec<T, Doubling>>
+where
+    P: PinnedVec<T>,
+{
+    core: PinnedConcurrentCol<T, P, ConcurrentOrderedBagState>,
+}
+
+impl<T, P> ConcurrentOrderedBag<T, P>
+where
+    P: PinnedVec<T>,
+{
+    /// Converts the bag into [`IntoInnerResult`] which might then unwrapped to access the underlying pinned vector.
+    pub fn into_inner(self) -> IntoInnerResult<P> {
+        let len = self.core.state().len();
+        let num_pushed = self.core.state().num_pushed();
+        match len.cmp(&num_pushed) {
+            Ordering::Equal => IntoInnerResult::LenMatchesNumPushes {
+                len,
+                vec: unsafe { self.core.into_inner(len) }.into(),
+            },
+            Ordering::Greater => IntoInnerResult::GreaterLenThanNumPushes {
+                len,
+                num_pushed,
+                vec: unsafe { self.core.into_inner(len) }.into(),
+            },
+            Ordering::Less => IntoInnerResult::LessLenThanNumPushes {
+                len,
+                num_pushed,
+                vec: unsafe { self.core.into_inner(len) }.into(),
+            },
+        }
+    }
+
+    /// ***O(1)*** Returns the length of the bag.
+    ///
+    /// *Length is assumed to be `m + 1`, where `m` is the index of the maximum position an element is written to.*
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use orx_concurrent_ordered_bag::ConcurrentOrderedBag;
+    ///
+    /// let bag = ConcurrentOrderedBag::new();
+    ///
+    /// unsafe { bag.set_value(2, 'c') };
+    /// assert_eq!(3, bag.len());
+    ///
+    /// unsafe { bag.set_values(0, ['a', 'b']) };
+    /// assert_eq!(3, bag.len());
+    ///
+    /// let vec = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
+    /// assert_eq!(vec, &['a', 'b', 'c']);
+    /// ```
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.core.state().len()
+    }
+
+    /// Returns whether or not the bag is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use orx_concurrent_ordered_bag::ConcurrentOrderedBag;
+    ///
+    /// let mut bag = ConcurrentOrderedBag::new();
+    ///
+    /// assert!(bag.is_empty());
+    ///
+    /// unsafe { bag.set_values(0, ['a', 'b']) };
+    /// assert!(!bag.is_empty());
+    ///
+    /// bag.clear();
+    /// assert!(bag.is_empty());
+    /// ```
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Sets the `idx`-th element of the collection to the given `value`.
+    ///
+    /// # Safety
+    ///
+    /// In a concurrent program, the caller is responsible to make sure that each position is written exactly and only once.
+    pub unsafe fn set_value(&self, idx: usize, value: T) {
+        self.core.write(idx, value);
+    }
+
+    /// Sets the elements in the range of `begin_idx..values.len()` positions of the collection to the given `values`.
+    ///
+    /// # Safety
+    ///
+    /// In a concurrent program, the caller is responsible to make sure that each position is written exactly and only once.
+    pub unsafe fn set_values<IntoIter, Iter>(&self, begin_idx: usize, values: IntoIter)
+    where
+        IntoIter: IntoIterator<Item = T, IntoIter = Iter>,
+        Iter: Iterator<Item = T> + ExactSizeIterator,
+    {
+        let values = values.into_iter();
+        let num_items = values.len();
+        self.set_n_values(begin_idx, num_items, values)
+    }
+
+    /// Sets the elements in the range of `begin_idx..(begin_idx + num_items)` positions of the collection to the given `values`.
+    ///
+    /// # Safety
+    ///
+    /// In a concurrent program, the caller is responsible to make sure that each position is written exactly and only once.
+    ///
+    /// Furthermore, `values` iterator must be capable of yielding at least (ideally, exactly) `num_items` elements.
+    pub unsafe fn set_n_values<IntoIter>(
+        &self,
+        begin_idx: usize,
+        num_items: usize,
+        values: IntoIter,
+    ) where
+        IntoIter: IntoIterator<Item = T>,
+    {
+        self.core.write_n_items(begin_idx, num_items, values)
+    }
+}
+
+// HELPERS
+
+impl<T, P> ConcurrentOrderedBag<T, P>
+where
+    P: PinnedVec<T>,
+{
+    pub(crate) fn new_from_pinned(pinned_vec: P) -> Self {
+        let core = PinnedConcurrentCol::new_from_pinned(pinned_vec);
+        Self { core }
+    }
+}
+
+// TRAITS
+
+impl<T, P> Deref for ConcurrentOrderedBag<T, P>
+where
+    P: PinnedVec<T>,
+{
+    type Target = PinnedConcurrentCol<T, P, ConcurrentOrderedBagState>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.core
+    }
+}
+
+impl<T, P> DerefMut for ConcurrentOrderedBag<T, P>
+where
+    P: PinnedVec<T>,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.core
+    }
+}
+
+unsafe impl<T: Sync, P: PinnedVec<T>> Sync for ConcurrentOrderedBag<T, P> {}
+
+unsafe impl<T: Send, P: PinnedVec<T>> Send for ConcurrentOrderedBag<T, P> {}

--- a/src/failures.rs
+++ b/src/failures.rs
@@ -1,0 +1,133 @@
+/// Result of [`crate::ConcurrentOrderedBag::into_inner`] call.
+pub enum IntoInnerResult<P> {
+    /// Length of the bag is equal to the number of elements pushed.
+    ///
+    /// *Length is assumed to be `m + 1`, where `m` is the index of the maximum position an element is written to.*
+    LenMatchesNumPushes {
+        /// Length of the bag.
+        ///
+        /// *Length is assumed to be `m + 1`, where `m` is the index of the maximum position an element is written to.*
+        len: usize,
+        /// Underlying pinned vector which can safely be `unwrapped` if the caller can guarantee that each element is written exactly once.
+        /// Otherwise, the vector might still contain gaps.
+        vec: MayFail<P>,
+    },
+    /// Number of pushes to the bag is greater than the length of the vector.
+    /// This indicates that at least one position is never written; and hence, there exists at least `len - num_pushed` gaps.
+    /// The caller is required to take the responsibility to unwrap.
+    ///
+    /// *Length is assumed to be `m + 1`, where `m` is the index of the maximum position an element is written to.*
+    GreaterLenThanNumPushes {
+        /// Length of the bag.
+        ///
+        /// *Length is assumed to be `m + 1`, where `m` is the index of the maximum position an element is written to.*
+        len: usize,
+        /// Number of times an element is written to the bag.
+        num_pushed: usize,
+        /// Underlying pinned vector has gaps.
+        /// The caller is required to take the responsibility to unwrap.
+        vec: MayFail<P>,
+    },
+    /// Number of pushes to the bag is greater than the length of the vector.
+    /// This indicates that at least one position is written at least twice, which is a violation of the safety requirement.
+    /// The caller is required to take the responsibility to unwrap.
+    ///
+    /// *Length is assumed to be `m + 1`, where `m` is the index of the maximum position an element is written to.*
+    LessLenThanNumPushes {
+        /// Length of the bag.
+        ///
+        /// *Length is assumed to be `m + 1`, where `m` is the index of the maximum position an element is written to.*
+        len: usize,
+        /// Number of times an element is written to the bag.
+        num_pushed: usize,
+        /// There has been multiple writes to the same position and there might still be gaps in the collection.
+        /// The caller is required to take the responsibility to unwrap.
+        vec: MayFail<P>,
+    },
+}
+
+impl<P> IntoInnerResult<P> {
+    /// Without checking the `IntoInnerResult` variant, directly unwraps and returns the underlying pinned vector.
+    ///
+    /// # Safety
+    ///
+    /// The underlying vector might be in an invalid condition if the safety requirements are not followed during concurrent growth:
+    /// * Each position is written exactly once, so that there exists no race condition.
+    /// * At the point where `into_inner` is called (not necessarily always), the bag must not contain any gaps.
+    ///   * Let `m` be the maximum index of the position that we write an element to.
+    ///   * The bag assumes that the length of the vector is equal to `m + 1`.
+    ///   * Then, it expects that exactly `m + 1` elements are written to the bag.
+    ///   * If the first condition was satisfied; then, this condition is sufficient to conclude that the bag can be converted to the underlying vector of `m + 1` elements.
+    pub unsafe fn unwrap(self) -> P {
+        match self {
+            IntoInnerResult::LenMatchesNumPushes { len: _, vec } => vec.unwrap(),
+            IntoInnerResult::GreaterLenThanNumPushes {
+                len: _,
+                num_pushed: _,
+                vec,
+            } => vec.unwrap(),
+            IntoInnerResult::LessLenThanNumPushes {
+                len: _,
+                num_pushed: _,
+                vec,
+            } => vec.unwrap(),
+        }
+    }
+
+    /// Unwraps and returns the pinned vector if the result is of [`IntoInnerResult::LenMatchesNumPushes`] variant, panics otherwise.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the result is not of the [`IntoInnerResult::LenMatchesNumPushes`] variant.
+    ///
+    /// # Safety
+    ///
+    /// The underlying vector might be in an invalid condition if the safety requirements are not followed during concurrent growth:
+    /// * Each position is written exactly once, so that there exists no race condition.
+    /// * At the point where `into_inner` is called (not necessarily always), the bag must not contain any gaps.
+    ///   * Let `m` be the maximum index of the position that we write an element to.
+    ///   * The bag assumes that the length of the vector is equal to `m + 1`.
+    ///   * Then, it expects that exactly `m + 1` elements are written to the bag.
+    ///   * If the first condition was satisfied; then, this condition is sufficient to conclude that the bag can be converted to the underlying vector of `m + 1` elements.
+    #[allow(clippy::panic)]
+    pub unsafe fn unwrap_only_if_counts_match(self) -> P {
+        match self {
+            IntoInnerResult::LenMatchesNumPushes { len: _, vec } => vec.unwrap(),
+            IntoInnerResult::GreaterLenThanNumPushes {
+                len,
+                num_pushed,
+                vec: _,
+            } => panic!("OrderedConcurrentBag surely contains gaps: {} elements are pushed; however, maximum index is {}.", num_pushed, len),
+            IntoInnerResult::LessLenThanNumPushes {
+                len,
+                num_pushed,
+                vec: _,
+            } => panic!("OrderedConcurrentBag surely contains gaps: {} elements are pushed; however, maximum index is {}.", num_pushed, len),
+        }
+    }
+}
+
+/// A wrapped value which can only be unwrapped through an unsafe call, leaving the decision or responsibility to the caller.
+pub struct MayFail<T>(T);
+
+impl<T> MayFail<T> {
+    /// Wraps the `value` as a `MayFail` value.
+    pub fn new(value: T) -> Self {
+        Self(value)
+    }
+
+    /// Unwraps and returns the underlying value.
+    ///
+    /// # Safety
+    ///
+    /// MayFail is a marker where the producer cannot make sure of safety of the underlying value, and leaves the decision to the caller to unsafely unwrap.
+    pub unsafe fn unwrap(self) -> T {
+        self.0
+    }
+}
+
+impl<P> From<P> for MayFail<P> {
+    fn from(value: P) -> Self {
+        Self::new(value)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,280 @@
+//! # orx-concurrent-ordered-bag
+//!
+//! [![orx-concurrent-ordered-bag crate](https://img.shields.io/crates/v/orx-concurrent-ordered-bag.svg)](https://crates.io/crates/orx-concurrent-ordered-bag)
+//! [![orx-concurrent-ordered-bag documentation](https://docs.rs/orx-concurrent-ordered-bag/badge.svg)](https://docs.rs/orx-concurrent-ordered-bag)
+//!
+//! An efficient, convenient and lightweight grow-only concurrent data structure allowing high performance and ordered concurrent collection.
+//!
+//! * **convenient**: `ConcurrentBag` can safely be shared among threads simply as a shared reference. It is a [`PinnedConcurrentCol`](https://crates.io/crates/orx-pinned-concurrent-col) with a special concurrent state implementation. Underlying [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) and concurrent bag can be converted back and forth to each other. Further, as you may see in the parallel map example, it enables efficient parallel methods with possibly the most convenient and simple implementation.
+//! * **efficient**: `ConcurrentBag` is a lock free structure making use of a few atomic primitives, this leads to high performance concurrent growth while enabling to collect the results in the desired order.
+//!
+//! ## Comparison to `ConcurrentBag`
+//!
+//! Note that [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-vec) is a similar structure with the following differences.
+//!
+//! ||`ConcurrentBag`|`ConcurrentOrderedBag`|
+//! |---|---|---|
+//! | Ordering | Cannot guarantee that the elements are in a desired order, the order of the collected elements depends on the time different threads push elements. | Allows to write to particular position enabling concurrently collecting elements in a desired order (fits very well to a parallel map). |
+//! | Safety of Growth | ConcurrentBag can be filled with safe `push` and `extend` calls. It makes sure that each position will be written to exactly once and there exists no race condition. | ConcurrentOrderedBag allows for more freedom by allowing to write to arbitrary positions of the collection. However, focusing on efficiency, it does not keep track of the filled positions. It is the caller's responsibility that every position is written only once and bag does not contain any gaps. Therefore, growth happens through unsafe `set_value`, `set_values` and `set_n_values` methods. However, as it will be clear in the examples that it is conveniently possible to achieve this guarantees with the help of [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter). |
+//! | Safety of `into_inner` | Into inner call cannot fail. Underlying pinned vector of a ConcurrentBag is always gap-free and valid; therefore, the bag can be converted into the underlying vector without care at any point in time. | Due to the above-mentioned reasons, ConcurrentOrderedBag might contain gaps. `into_inner` call provides some useful metrics such as number of elements pushed and maximum index of the vector; however, it cannot guarantee that the bag is gap-free. Therefore, the caller is required to take responsibility to unwrap the pinned vec or not through an unsafe call. |
+//!
+//! ## Safety Requirements
+//!
+//! As the comparison reveals, `ConcurrentBag` is much safer to use than `ConcurrentOrderedBag`, which could be the first choice if the order of collected elements does not matter. On the other hand, required safety guarantees fortunately are not too difficult to satisfy. ConcurrentOrderedBag can safely be used provided that the following two conditions are satisfied:
+//! * Each position is written exactly once, so that there exists no race condition.
+//! * At the point where `into_inner` is called (not necessarily always), the bag must not contain any gaps.
+//!   * Let `m` be the maximum index of the position that we write an element to.
+//!   * The bag assumes that the length of the vector is equal to `m + 1`.
+//!   * Then, it expects that exactly `m + 1` elements are written to the bag.
+//!   * If the first condition was satisfied; then, this condition is sufficient to conclude that the bag can be converted to the underlying vector of `m + 1` elements.
+//!
+//! ## Examples
+//!
+//! Safety guarantees to push to the bag with a shared reference makes it easy to share the bag among threads. However, the caller is required to make sure that the collection does not contain gaps and each position is written exactly once.
+//!
+//! ### Manual Example
+//!
+//! In the following example, we split computation among two threads: the first thread processes inputs with even indices, and the second with odd indices. This provides the required guarantee mentioned above.
+//!
+//! ```rust
+//! use orx_concurrent_ordered_bag::*;
+//!
+//! let n = 1024;
+//!
+//! let evens_odds = ConcurrentOrderedBag::new();
+//!
+//! // just take a reference and share among threads
+//! let bag = &evens_odds;
+//!
+//! std::thread::scope(|s| {
+//!     s.spawn(move || {
+//!         for i in (0..n).filter(|x| x % 2 == 0) {
+//!             unsafe { bag.set_value(i, i as i32) };
+//!         }
+//!     });
+//!
+//!     s.spawn(move || {
+//!         for i in (0..n).filter(|x| x % 2 == 1) {
+//!             unsafe { bag.set_value(i, -(i as i32)) };
+//!         }
+//!     });
+//! });
+//!
+//! let vec = unsafe { evens_odds.into_inner().unwrap_only_if_counts_match() };
+//! assert_eq!(vec.len(), n);
+//! for i in 0..n {
+//!     if i % 2 == 0 {
+//!         assert_eq!(vec[i], i as i32);
+//!     } else {
+//!         assert_eq!(vec[i], -(i as i32));
+//!     }
+//! }
+//! ```
+//!
+//! Note that as long as no-gap and write-only-once guarantees are satisfied, `ConcurrentOrderedBag` is very flexible in the order of writes. They can simply happen in arbitrary order. Consider the following instance for instance. We spawn a thread just two write to the end of the collection, and then spawn a bunch of other threads to fill the beginning of the collection. This just works without any locks or waits.
+//!
+//! ```rust
+//! use orx_concurrent_ordered_bag::*;
+//!
+//! let n = 1024;
+//! let num_additional_threads = 4;
+//!
+//! let bag = ConcurrentOrderedBag::new();
+//! let con_bag = &bag;
+//!
+//! std::thread::scope(|s| {
+//!     s.spawn(move || {
+//!         // start writing to the end
+//!         unsafe { con_bag.set_value(n - 1, 42) };
+//!     });
+//!
+//!     for thread in 0..num_additional_threads {
+//!         s.spawn(move || {
+//!             // then fill the rest concurrently from the beginning
+//!             for i in (0..(n - 1)).filter(|i| i % num_additional_threads == thread) {
+//!                 unsafe { con_bag.set_value(i, i as i32) };
+//!             }
+//!         });
+//!     }
+//! });
+//!
+//! let vec = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
+//! assert_eq!(vec.len(), n);
+//! for i in 0..(n - 1) {
+//!     assert_eq!(vec[i], i as i32);
+//! }
+//! assert_eq!(vec[n - 1], 42);
+//! ```
+//!
+//! These examples represent cases where the work can be trivially split among threads while providing the safety requirements. However, it requires special care and correctness. This complexity can significantly be avoided by pairing the `ConcurrentOrderedBag` with a [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter) on the input side.
+//!
+//! ### Parallel Map with `ConcurrentIter`
+//!
+//! Parallel map operation is one of the cases where we would care about the order of the collected elements, and hence, `ConcurrentBag` would not suffice. On the other hand, an efficient implementation can be achieved with `ConcurrentOrderedBag` and `ConcurrentIter`. Further, it might **possibly be the most convenient parallel map** implementation that is almost identical to a single-threaded map implementation.
+//!
+//! ```rust
+//! use orx_concurrent_ordered_bag::*;
+//! use orx_concurrent_iter::*;
+//!
+//! fn parallel_map<In, Out, Map, Inputs>(
+//!     num_threads: usize,
+//!     inputs: Inputs,
+//!     map: &Map,
+//! ) -> ConcurrentOrderedBag<Out>
+//! where
+//!     Inputs: ConcurrentIter<Item = In>,
+//!     Map: Fn(In) -> Out + Send + Sync,
+//!     Out: Send + Sync,
+//! {
+//!     let outputs = ConcurrentOrderedBag::new();
+//!     let inputs = &inputs;
+//!     let out = &outputs;
+//!     std::thread::scope(|s| {
+//!         for _ in 0..num_threads {
+//!             s.spawn(|| {
+//!                 while let Some(next) = inputs.next_id_and_value() {
+//!                     unsafe { out.set_value(next.idx, map(next.value)) };
+//!                 }
+//!             });
+//!         }
+//!     });
+//!     outputs
+//! }
+//!
+//! let len = 2465;
+//! let vec: Vec<_> = (0..len).map(|x| x.to_string()).collect();
+//!
+//! let bag = parallel_map(4, vec.into_con_iter(), &|x| x.to_string().len());
+//! let output = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
+//!
+//! assert_eq!(output.len(), len);
+//! for (i, value) in output.iter().enumerate() {
+//!     assert_eq!(value, &i.to_string().len());
+//! }
+//! ```
+//!
+//! As you may see, we are not required to share the work manually, we simply use a `while let Some` loop. The work is pulled by threads from the iterator. This both leads to an efficient implementation especially in cases of heterogeneous work loads of each task and automatically provides the safety requirements.
+//!
+//!
+//! ### Parallel Map with `ExactSizeConcurrentIter`
+//!
+//! A further performance improvement to the parallel map implementation above is to distribute the tasks among the threads in chunks. The aim of this approach is to avoid false sharing, you may see further details [here](https://docs.rs/orx-concurrent-bag/latest/orx_concurrent_bag/#section-performance-notes). This can be achieved by pairing an [`ExactSizeConcurrentIter`](https://docs.rs/orx-concurrent-iter/latest/orx_concurrent_iter/trait.ExactSizeConcurrentIter.html) rather than a ConcurrentIter with the `set_values` method of the `ConcurrentOrderedBag`.
+//!
+//! ```rust
+//! use orx_concurrent_ordered_bag::*;
+//! use orx_concurrent_iter::*;
+//!
+//! fn parallel_map<In, Out, Map, Inputs>(
+//!     num_threads: usize,
+//!     inputs: Inputs,
+//!     map: &Map,
+//!     chunk_size: usize,
+//! ) -> ConcurrentOrderedBag<Out>
+//! where
+//!     Inputs: ExactSizeConcurrentIter<Item = In>,
+//!     Map: Fn(In) -> Out + Send + Sync,
+//!     Out: Send + Sync,
+//! {
+//!     let outputs = ConcurrentOrderedBag::new();
+//!     let inputs = &inputs;
+//!     let out = &outputs;
+//!     std::thread::scope(|s| {
+//!         for _ in 0..num_threads {
+//!             s.spawn(|| {
+//!                 while let Some(next) = inputs.next_exact_chunk(chunk_size) {
+//!                     unsafe { out.set_values(next.begin_idx(), next.values().map(map)) };
+//!                 }
+//!             });
+//!         }
+//!     });
+//!     outputs
+//! }
+//!
+//! let len = 2465;
+//! let vec: Vec<_> = (0..len).map(|x| x.to_string()).collect();
+//! let bag = parallel_map(4, vec.into_con_iter(), &|x| x.to_string().len(), 64);
+//! let output = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
+//! for (i, value) in output.iter().enumerate() {
+//!     assert_eq!(value, &i.to_string().len());
+//! }
+//! ```
+//!
+//! ### Construction
+//!
+//! `ConcurrentOrderedBag` can be constructed by wrapping any pinned vector; i.e., `ConcurrentOrderedBag<T>` implements `From<P: PinnedVec<T>>`. Likewise, a concurrent vector can be unwrapped without any allocation to the underlying pinned vector with `into_inner` method, provided that the safety requirements are satisfied.
+//!
+//! Further, there exist `with_` methods to directly construct the concurrent bag with common pinned vector implementations.
+//!
+//! ```rust
+//! use orx_concurrent_ordered_bag::*;
+//!
+//! // default pinned vector -> SplitVec<T, Doubling>
+//! let bag: ConcurrentOrderedBag<char> = ConcurrentOrderedBag::new();
+//! let bag: ConcurrentOrderedBag<char> = Default::default();
+//! let bag: ConcurrentOrderedBag<char> = ConcurrentOrderedBag::with_doubling_growth();
+//! let bag: ConcurrentOrderedBag<char, SplitVec<char, Doubling>> = ConcurrentOrderedBag::with_doubling_growth();
+//!
+//! let bag: ConcurrentOrderedBag<char> = SplitVec::new().into();
+//! let bag: ConcurrentOrderedBag<char, SplitVec<char, Doubling>> = SplitVec::new().into();
+//!
+//! // SplitVec with [Linear](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Linear.html) growth
+//! // each fragment will have capacity 2^10 = 1024
+//! // and the split vector can grow up to 32 fragments
+//! let bag: ConcurrentOrderedBag<char, SplitVec<char, Linear>> = ConcurrentOrderedBag::with_linear_growth(10, 32);
+//! let bag: ConcurrentOrderedBag<char, SplitVec<char, Linear>> = SplitVec::with_linear_growth_and_fragments_capacity(10, 32).into();
+//!
+//! // [FixedVec](https://docs.rs/orx-fixed-vec/latest/orx_fixed_vec/) with fixed capacity.
+//! // Fixed vector cannot grow; hence, pushing the 1025-th element to this bag will cause a panic!
+//! let bag: ConcurrentOrderedBag<char, FixedVec<char>> = ConcurrentOrderedBag::with_fixed_capacity(1024);
+//! let bag: ConcurrentOrderedBag<char, FixedVec<char>> = FixedVec::new(1024).into();
+//! ```
+//!
+//! Of course, the pinned vector to be wrapped does not need to be empty.
+//!
+//! ```rust
+//! use orx_concurrent_ordered_bag::*;
+//!
+//! let split_vec: SplitVec<i32> = (0..1024).collect();
+//! let bag: ConcurrentOrderedBag<_> = split_vec.into();
+//! ```
+//!
+//! ## Concurrent State and Properties
+//!
+//! The concurrent state is modeled simply by an atomic capacity. Combination of this state and `PinnedConcurrentCol` leads to the following properties:
+//! * Writing to a position of the collection does not block other writes, multiple writes can happen concurrently.
+//! * Caller is required to guarantee that each position is written exactly once.
+//! * ⟹ caller is responsible to avoid write & write race conditions.
+//! * Only one growth can happen at a given time.
+//! * Reading is only possible after converting the bag into the underlying `PinnedVec`.
+//! * ⟹ no read & write race condition exists.
+//!
+//! ## License
+//!
+//! This library is licensed under MIT license. See LICENSE for details.
+
+#![warn(
+    missing_docs,
+    clippy::unwrap_in_result,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::float_cmp,
+    clippy::float_cmp_const,
+    clippy::missing_panics_doc,
+    clippy::todo
+)]
+
+mod bag;
+mod failures;
+mod new;
+mod state;
+
+/// Common relevant traits, structs, enums.
+pub mod prelude;
+
+pub use bag::ConcurrentOrderedBag;
+pub use failures::{IntoInnerResult, MayFail};
+
+pub use orx_fixed_vec::FixedVec;
+pub use orx_pinned_vec::{CapacityState, PinnedVec, PinnedVecGrowthError};
+pub use orx_split_vec::{Doubling, Linear, Recursive, SplitVec};

--- a/src/new.rs
+++ b/src/new.rs
@@ -1,0 +1,79 @@
+use crate::bag::ConcurrentOrderedBag;
+use orx_fixed_vec::{FixedVec, PinnedVec};
+use orx_split_vec::{Doubling, Linear, Recursive, SplitVec};
+
+impl<T> Default for ConcurrentOrderedBag<T, SplitVec<T, Doubling>> {
+    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<T, Doubling>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Doubling.html) as the underlying storage.
+    fn default() -> Self {
+        Self::with_doubling_growth()
+    }
+}
+
+impl<T> ConcurrentOrderedBag<T, SplitVec<T, Doubling>> {
+    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<T, Doubling>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Doubling.html) as the underlying storage.
+    pub fn new() -> Self {
+        Self::with_doubling_growth()
+    }
+
+    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<T, Doubling>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Doubling.html) as the underlying storage.
+    pub fn with_doubling_growth() -> Self {
+        Self::new_from_pinned(SplitVec::with_doubling_growth_and_fragments_capacity(32))
+    }
+}
+
+impl<T> ConcurrentOrderedBag<T, SplitVec<T, Recursive>> {
+    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<T, Recursive>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Recursive.html) as the underlying storage.
+    pub fn with_recursive_growth() -> Self {
+        Self::new_from_pinned(SplitVec::with_recursive_growth_and_fragments_capacity(32))
+    }
+}
+
+impl<T> ConcurrentOrderedBag<T, SplitVec<T, Linear>> {
+    /// Creates a new concurrent bag by creating and wrapping up a new [`SplitVec<T, Linear>`](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Linear.html) as the underlying storage.
+    ///
+    /// * Each fragment of the split vector will have a capacity of  `2 ^ constant_fragment_capacity_exponent`.
+    /// * Further, fragments collection of the split vector will have a capacity of `fragments_capacity` on initialization.
+    ///
+    /// This leads to a [`orx_pinned_concurrent_col::PinnedConcurrentCol::maximum_capacity`] of `fragments_capacity * 2 ^ constant_fragment_capacity_exponent`.
+    ///
+    /// Whenever this capacity is not sufficient, fragments capacity can be increased by using the  [`orx_pinned_concurrent_col::PinnedConcurrentCol::reserve_maximum_capacity`] method.    
+    pub fn with_linear_growth(
+        constant_fragment_capacity_exponent: usize,
+        fragments_capacity: usize,
+    ) -> Self {
+        Self::new_from_pinned(SplitVec::with_linear_growth_and_fragments_capacity(
+            constant_fragment_capacity_exponent,
+            fragments_capacity,
+        ))
+    }
+}
+
+impl<T> ConcurrentOrderedBag<T, FixedVec<T>> {
+    /// Creates a new concurrent bag by creating and wrapping up a new [`FixedVec<T>`]((https://docs.rs/orx-fixed-vec/latest/orx_fixed_vec/)) as the underlying storage.
+    ///
+    /// # Safety
+    ///
+    /// Note that a `FixedVec` cannot grow; i.e., it has a hard upper bound on the number of elements it can hold, which is the `fixed_capacity`.
+    ///
+    /// Pushing to the vector beyond this capacity leads to "out-of-capacity" error.
+    ///
+    /// This maximum capacity can be accessed by [`orx_pinned_concurrent_col::PinnedConcurrentCol::capacity`] or [`orx_pinned_concurrent_col::PinnedConcurrentCol::maximum_capacity`] methods.
+    pub fn with_fixed_capacity(fixed_capacity: usize) -> Self {
+        Self::new_from_pinned(FixedVec::new(fixed_capacity))
+    }
+}
+
+// from
+impl<T, P> From<P> for ConcurrentOrderedBag<T, P>
+where
+    P: PinnedVec<T>,
+{
+    /// `ConcurrentBag<T>` uses any `PinnedVec<T>` implementation as the underlying storage.
+    ///
+    /// Therefore, without a cost
+    /// * `ConcurrentBag<T>` can be constructed from any `PinnedVec<T>`, and
+    /// * the underlying `PinnedVec<T>` can be obtained by `ConcurrentBag::into_inner(self)` method.
+    fn from(pinned_vec: P) -> Self {
+        Self::new_from_pinned(pinned_vec)
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,6 @@
+pub use crate::bag::ConcurrentOrderedBag;
+pub use crate::failures::{IntoInnerResult, MayFail};
+
+pub use orx_fixed_vec::FixedVec;
+pub use orx_pinned_vec::{CapacityState, PinnedVec, PinnedVecGrowthError};
+pub use orx_split_vec::{Doubling, Linear, Recursive, SplitVec};

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,70 @@
+use orx_pinned_concurrent_col::{ConcurrentState, PinnedConcurrentCol, WritePermit};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+pub struct ConcurrentOrderedBagState {
+    is_growing: AtomicBool,
+    len: AtomicUsize,
+    num_pushed: AtomicUsize,
+}
+
+impl ConcurrentState for ConcurrentOrderedBagState {
+    fn zero_memory(&self) -> bool {
+        false
+    }
+
+    fn new_for_pinned_vec<T, P: orx_fixed_vec::prelude::PinnedVec<T>>(pinned_vec: &P) -> Self {
+        Self {
+            is_growing: false.into(),
+            len: pinned_vec.len().into(),
+            num_pushed: pinned_vec.len().into(),
+        }
+    }
+
+    fn write_permit<T, P, S>(&self, col: &PinnedConcurrentCol<T, P, S>, idx: usize) -> WritePermit
+    where
+        P: orx_fixed_vec::prelude::PinnedVec<T>,
+        S: ConcurrentState,
+    {
+        match idx.cmp(&col.capacity()) {
+            std::cmp::Ordering::Less => WritePermit::JustWrite,
+            _ => {
+                let was_growing = self.is_growing.fetch_or(true, Ordering::SeqCst);
+                let can_grow = !was_growing;
+
+                match can_grow {
+                    true => {
+                        let new_capacity = std::hint::black_box(col.capacity());
+                        if idx < new_capacity {
+                            self.is_growing.store(false, Ordering::SeqCst);
+                            WritePermit::JustWrite
+                        } else {
+                            WritePermit::GrowThenWrite
+                        }
+                    }
+                    false => WritePermit::Spin,
+                }
+            }
+        }
+    }
+    #[inline(always)]
+    fn release_growth_handle(&self) {
+        let prior = self.is_growing.fetch_and(false, Ordering::SeqCst);
+        assert!(prior);
+    }
+
+    fn update_after_write(&self, begin_idx: usize, end_idx: usize) {
+        _ = self.len.fetch_max(end_idx, Ordering::AcqRel);
+        self.num_pushed
+            .fetch_add(end_idx - begin_idx, Ordering::AcqRel);
+    }
+}
+
+impl ConcurrentOrderedBagState {
+    // get
+    pub fn len(&self) -> usize {
+        self.len.load(Ordering::Relaxed)
+    }
+    pub fn num_pushed(&self) -> usize {
+        self.num_pushed.load(Ordering::Relaxed)
+    }
+}

--- a/tests/parallel_map.rs
+++ b/tests/parallel_map.rs
@@ -1,0 +1,90 @@
+use orx_concurrent_iter::{ExactSizeConcurrentIter, IntoConcurrentIter, NextChunk};
+use orx_concurrent_ordered_bag::*;
+use orx_pinned_vec::PinnedVec;
+use test_case::test_matrix;
+
+fn parallel_map<In, Out, Map, Inputs>(
+    num_threads: usize,
+    inputs: Inputs,
+    map: &Map,
+    chunk_size: usize,
+) -> ConcurrentOrderedBag<Out>
+where
+    Inputs: ExactSizeConcurrentIter<Item = In>,
+    Map: Fn(In) -> Out + Send + Sync,
+    Out: Send + Sync,
+{
+    let outputs = ConcurrentOrderedBag::new();
+
+    let inputs = &inputs;
+    let out = &outputs;
+
+    std::thread::scope(|s| {
+        for _ in 0..num_threads {
+            s.spawn(|| {
+                while let Some(next) = inputs.next_exact_chunk(chunk_size) {
+                    unsafe { out.set_values(next.begin_idx(), next.values().map(map)) };
+                }
+            });
+        }
+    });
+
+    outputs
+}
+
+fn validate_output<P: PinnedVec<usize>>(output: ConcurrentOrderedBag<usize, P>, len: usize) {
+    let output = unsafe { output.into_inner().unwrap_only_if_counts_match() };
+    assert_eq!(output.len(), len);
+
+    for (i, value) in output.iter().enumerate() {
+        assert_eq!(value, &i.to_string().len().max(1));
+    }
+}
+
+#[test_matrix(
+    [1, 4, 8],
+    [1, 4, 245, 1024],
+    [1, 4, 64, 128]
+)]
+fn pll_map_range(num_threads: usize, len: usize, chunk_size: usize) {
+    let range = 0..len;
+    let output = parallel_map(
+        num_threads,
+        range.into_con_iter(),
+        &|x| x.to_string().len().max(1),
+        chunk_size,
+    );
+    validate_output(output, len)
+}
+
+#[test_matrix(
+    [1, 4, 8],
+    [1, 4, 245, 1024],
+    [1, 4, 64, 128]
+)]
+fn pll_map_vec(num_threads: usize, len: usize, chunk_size: usize) {
+    let vec: Vec<_> = (0..len).map(|x| x.to_string()).collect();
+    let output = parallel_map(
+        num_threads,
+        vec.into_con_iter(),
+        &|x| x.to_string().len().max(1),
+        chunk_size,
+    );
+    validate_output(output, len)
+}
+
+#[test_matrix(
+    [1, 4, 8],
+    [1, 4, 245, 1024],
+    [1, 4, 64, 128]
+)]
+fn pll_map_slice(num_threads: usize, len: usize, chunk_size: usize) {
+    let vec: Vec<_> = (0..len).map(|x| x.to_string()).collect();
+    let output = parallel_map(
+        num_threads,
+        vec.as_slice().into_con_iter(),
+        &|x| x.to_string().len().max(1),
+        chunk_size,
+    );
+    validate_output(output, len)
+}

--- a/tests/set_con_iter.rs
+++ b/tests/set_con_iter.rs
@@ -1,0 +1,122 @@
+use orx_concurrent_iter::{ConcurrentIter, IntoConcurrentIter, IterIntoConcurrentIter};
+use orx_concurrent_ordered_bag::*;
+use orx_pinned_vec::PinnedVec;
+use test_case::test_matrix;
+
+const NUM_RERUNS: usize = 1;
+
+#[test_matrix(
+    [1, 2, 4, 8],
+    [4, 124, 348, 1024, 2587]
+)]
+fn vec_into_con_iter(num_threads: usize, len: usize) {
+    for _ in 0..NUM_RERUNS {
+        let vec: Vec<_> = (0..len).collect();
+        let iter = vec.into_con_iter();
+        let con_iter = &iter;
+
+        let bag = ConcurrentOrderedBag::new();
+        let con_bag = &bag;
+
+        std::thread::scope(|s| {
+            for _ in 0..num_threads {
+                s.spawn(move || {
+                    for (idx, value) in con_iter.ids_and_values() {
+                        unsafe { con_bag.set_value(idx, process(value)) };
+                    }
+                });
+            }
+        });
+
+        let vec = unsafe { bag.into_inner().unwrap() };
+        for (i, value) in vec.iter().enumerate() {
+            let expected_value = process(i);
+            assert_eq!(value, &expected_value);
+        }
+    }
+}
+
+#[test_matrix(
+    [1, 2, 4, 8],
+    [4, 124, 348, 1024, 2587]
+)]
+fn iter_into_con_iter_long_yield(num_threads: usize, len: usize) {
+    for _ in 0..NUM_RERUNS {
+        let vec: Vec<_> = (0..len).collect();
+        let iter = vec
+            .iter()
+            .map(|x| {
+                let mut sum = 1f64;
+                for i in 0..(1024 * 16) {
+                    let y = ((i + 1) as f64).ln();
+                    let z = y * 2.0 + i as f64;
+                    sum += z;
+                }
+                assert!(sum > 0f64);
+                x
+            })
+            .into_con_iter();
+        let con_iter = &iter;
+
+        let bag = ConcurrentOrderedBag::new();
+        let con_bag = &bag;
+
+        std::thread::scope(|s| {
+            for _ in 0..num_threads {
+                s.spawn(move || {
+                    for (idx, value) in con_iter.ids_and_values() {
+                        unsafe { con_bag.set_value(idx, process(*value)) };
+                    }
+                });
+            }
+        });
+
+        let vec = unsafe { bag.into_inner().unwrap() };
+        for (i, value) in vec.iter().enumerate() {
+            let expected_value = process(i);
+            assert_eq!(value, &expected_value);
+        }
+    }
+}
+
+#[test_matrix(
+    [1, 2, 4, 8],
+    [4, 124, 348, 1024, 2587]
+)]
+fn vec_into_con_iter_long_process(num_threads: usize, len: usize) {
+    for _ in 0..NUM_RERUNS {
+        let vec: Vec<_> = (0..len).collect();
+        let iter = vec.into_con_iter();
+        let con_iter = &iter;
+
+        let bag = ConcurrentOrderedBag::new();
+        let con_bag = &bag;
+
+        std::thread::scope(|s| {
+            for _ in 0..num_threads {
+                s.spawn(move || {
+                    for (idx, value) in con_iter.ids_and_values() {
+                        let mut sum = 1f64;
+                        for i in 0..(1024 * 16) {
+                            let y = ((i + 1 + value) as f64).ln();
+                            let z = y * 2.0 + i as f64;
+                            sum += z;
+                        }
+                        assert!(sum > 0f64);
+                        unsafe { con_bag.set_value(idx, process(value)) };
+                    }
+                });
+            }
+        });
+
+        let vec = unsafe { bag.into_inner().unwrap() };
+        for (i, value) in vec.iter().enumerate() {
+            let expected_value = process(i);
+            assert_eq!(value, &expected_value);
+        }
+    }
+}
+
+fn process(number: usize) -> String {
+    format!("from-thread-{}", number)
+}

--- a/tests/set_value.rs
+++ b/tests/set_value.rs
@@ -1,0 +1,98 @@
+use orx_concurrent_ordered_bag::*;
+use orx_pinned_vec::PinnedVec;
+use test_case::test_matrix;
+
+#[test_matrix([1, 2, 4, 1024, 2587, 42578])]
+fn write_at_odd_even_indices(n: usize) {
+    let bag = ConcurrentOrderedBag::new();
+    let con_bag = &bag;
+
+    std::thread::scope(|s| {
+        s.spawn(move || {
+            for i in (0..n).filter(|x| x % 2 == 0) {
+                unsafe { con_bag.set_value(i, i as i32) };
+            }
+        });
+
+        s.spawn(move || {
+            for i in (0..n).filter(|x| x % 2 == 1) {
+                unsafe { con_bag.set_value(i, -(i as i32)) };
+            }
+        });
+    });
+
+    let vec = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
+    for i in 0..n {
+        if i % 2 == 0 {
+            assert_eq!(vec[i], i as i32);
+        } else {
+            assert_eq!(vec[i], -(i as i32));
+        }
+    }
+}
+
+#[test_matrix([124, 348, 1024, 2587, 42578])]
+fn non_uniform(n: usize) {
+    let bag = ConcurrentOrderedBag::new();
+    let con_bag = &bag;
+
+    fn second_indices(n: usize) -> [usize; 3] {
+        [n / 3, 2 * n / 2, n - 1]
+    }
+
+    std::thread::scope(|s| {
+        s.spawn(move || {
+            let specials = second_indices(n);
+            for i in (0..n).filter(|x| !specials.contains(x)) {
+                unsafe { con_bag.set_value(i, i as i32) };
+            }
+        });
+
+        s.spawn(move || {
+            let specials = second_indices(n);
+            for i in (0..n).filter(|x| specials.contains(x)) {
+                unsafe { con_bag.set_value(i, 1000 + i as i32) };
+            }
+        });
+    });
+
+    let specials = second_indices(n);
+    let vec = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
+    for i in 0..n {
+        if specials.contains(&i) {
+            assert_eq!(vec[i], 1000 + i as i32);
+        } else {
+            assert_eq!(vec[i], i as i32);
+        }
+    }
+}
+
+#[test_matrix(
+    [1, 2, 4, 8],
+    [4, 124, 348, 1024, 2587]
+)]
+fn early_alloc(num_additional_threads: usize, len: usize) {
+    let bag = ConcurrentOrderedBag::new();
+    let con_bag = &bag;
+
+    std::thread::scope(|s| {
+        s.spawn(move || {
+            unsafe { con_bag.set_value(len - 1, 42) };
+        });
+
+        for thread in 0..num_additional_threads {
+            s.spawn(move || {
+                for i in (0..(len - 1)).filter(|i| i % num_additional_threads == thread) {
+                    unsafe { con_bag.set_value(i, i as i32) };
+                }
+            });
+        }
+    });
+
+    let vec = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
+    assert_eq!(vec.len(), len);
+    for i in 0..(len - 1) {
+        assert_eq!(vec[i], i as i32);
+    }
+    assert_eq!(vec[len - 1], 42);
+}

--- a/tests/set_values.rs
+++ b/tests/set_values.rs
@@ -1,0 +1,120 @@
+use orx_concurrent_ordered_bag::*;
+use orx_pinned_vec::PinnedVec;
+use test_case::test_matrix;
+
+#[test_matrix(
+    [1, 2, 4, 1024, 2587],
+    [1, 4, 64, 128]
+)]
+fn write_at_odd_even_batches(num_batches: usize, batch_size: usize) {
+    let bag = ConcurrentOrderedBag::new();
+    let con_bag = &bag;
+
+    std::thread::scope(|s| {
+        s.spawn(move || {
+            for b in (0..num_batches).filter(|x| x % 2 == 0) {
+                let beg_idx = b * batch_size;
+                let values = (0..batch_size).map(|_| b as i32);
+                unsafe { con_bag.set_values(beg_idx, values) };
+            }
+        });
+
+        s.spawn(move || {
+            for b in (0..num_batches).filter(|x| x % 2 == 1) {
+                let beg_idx = b * batch_size;
+                let values = (0..batch_size).map(|_| -(b as i32));
+                unsafe { con_bag.set_values(beg_idx, values) };
+            }
+        });
+    });
+
+    let vec = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
+    assert_eq!(vec.len(), num_batches * batch_size);
+    for b in 0..num_batches {
+        let expected_value = if b % 2 == 0 { b as i32 } else { -(b as i32) };
+        let beg_idx = b * batch_size;
+        let end_idx = beg_idx + batch_size;
+        for i in beg_idx..end_idx {
+            assert_eq!(vec[i], expected_value);
+        }
+    }
+}
+
+#[test_matrix(
+    [1, 2, 4, 1024, 2587],
+    [1, 4, 64, 128]
+)]
+fn non_uniform_batches(num_batches: usize, batch_size: usize) {
+    let bag = ConcurrentOrderedBag::new();
+    let con_bag = &bag;
+
+    fn second_indices(n: usize) -> [usize; 3] {
+        [n / 3, 2 * n / 2, n - 1]
+    }
+
+    std::thread::scope(|s| {
+        s.spawn(move || {
+            let specials = second_indices(num_batches);
+            for b in (0..num_batches).filter(|x| !specials.contains(x)) {
+                let beg_idx = b * batch_size;
+                let values = (0..batch_size).map(|_| b as i32);
+                unsafe { con_bag.set_values(beg_idx, values) };
+            }
+        });
+
+        s.spawn(move || {
+            let specials = second_indices(num_batches);
+            for b in (0..num_batches).filter(|x| specials.contains(x)) {
+                let beg_idx = b * batch_size;
+                let values = (0..batch_size).map(|_| -(b as i32));
+                unsafe { con_bag.set_values(beg_idx, values) };
+            }
+        });
+    });
+
+    let specials = second_indices(num_batches);
+    let vec = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
+    assert_eq!(vec.len(), num_batches * batch_size);
+    for b in 0..num_batches {
+        let expected_value = if !specials.contains(&b) {
+            b as i32
+        } else {
+            -(b as i32)
+        };
+        let beg_idx = b * batch_size;
+        let end_idx = beg_idx + batch_size;
+        for i in beg_idx..end_idx {
+            assert_eq!(vec[i], expected_value);
+        }
+    }
+}
+
+#[test_matrix(
+    [1, 2, 4, 8],
+    [4, 124, 348, 1024, 2587]
+)]
+fn early_alloc_batch(num_additional_threads: usize, num_batches: usize) {
+    let bag = ConcurrentOrderedBag::new();
+    let con_bag = &bag;
+
+    std::thread::scope(|s| {
+        s.spawn(move || {
+            unsafe { con_bag.set_values(num_batches - 1, std::iter::once(42)) };
+        });
+
+        for thread in 0..num_additional_threads {
+            s.spawn(move || {
+                for i in (0..(num_batches - 1)).filter(|i| i % num_additional_threads == thread) {
+                    unsafe { con_bag.set_values(i, std::iter::once(i as i32)) };
+                }
+            });
+        }
+    });
+
+    let vec = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
+    assert_eq!(vec.len(), num_batches);
+    for i in 0..(num_batches - 1) {
+        assert_eq!(vec[i], i as i32);
+    }
+    assert_eq!(vec[num_batches - 1], 42);
+}

--- a/tests/set_values_con_iter.rs
+++ b/tests/set_values_con_iter.rs
@@ -1,0 +1,84 @@
+use orx_concurrent_iter::{ExactSizeConcurrentIter, IntoConcurrentIter, NextChunk};
+use orx_concurrent_ordered_bag::*;
+use orx_pinned_vec::PinnedVec;
+use test_case::test_matrix;
+
+const NUM_RERUNS: usize = 1;
+
+#[test_matrix(
+    [1, 2, 4, 8],
+    [4, 124, 2587],
+    [1, 4, 64]
+)]
+fn write_at_odd_even_batches(num_threads: usize, len: usize, chunk_size: usize) {
+    for _ in 0..NUM_RERUNS {
+        let vec: Vec<_> = (0..len).collect();
+        let iter = vec.into_con_iter();
+        let con_iter = &iter;
+
+        let bag = ConcurrentOrderedBag::new();
+        let con_bag = &bag;
+
+        std::thread::scope(|s| {
+            for _ in 0..num_threads {
+                s.spawn(move || {
+                    while let Some(next) = con_iter.next_exact_chunk(chunk_size) {
+                        unsafe { con_bag.set_values(next.begin_idx(), next.values().map(process)) };
+                    }
+                });
+            }
+        });
+
+        let vec = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
+        for (i, value) in vec.iter().enumerate() {
+            let expected_value = process(i);
+            assert_eq!(value, &expected_value);
+        }
+    }
+}
+
+#[test_matrix(
+    [1, 2, 4, 8],
+    [4, 124, 2587],
+    [1, 4, 64]
+)]
+fn vec_into_con_iter_long_process(num_threads: usize, len: usize, chunk_size: usize) {
+    for _ in 0..NUM_RERUNS {
+        let vec: Vec<_> = (0..len).collect();
+        let iter = vec.into_con_iter();
+        let con_iter = &iter;
+
+        let bag = ConcurrentOrderedBag::new();
+        let con_bag = &bag;
+
+        std::thread::scope(|s| {
+            for _ in 0..num_threads {
+                s.spawn(move || {
+                    while let Some(next) = con_iter.next_exact_chunk(chunk_size) {
+                        let idx = next.begin_idx();
+                        let value = idx + 1;
+                        let mut sum = 1f64;
+                        for i in 0..(1024 * 16) {
+                            let y = ((i + 1 + value) as f64).ln();
+                            let z = y * 2.0 + i as f64;
+                            sum += z;
+                        }
+                        assert!(sum > 0f64);
+
+                        unsafe { con_bag.set_values(next.begin_idx(), next.values().map(process)) };
+                    }
+                });
+            }
+        });
+
+        let vec = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
+        for (i, value) in vec.iter().enumerate() {
+            let expected_value = process(i);
+            assert_eq!(value, &expected_value);
+        }
+    }
+}
+
+fn process(number: usize) -> String {
+    format!("from-thread-{}", number)
+}


### PR DESCRIPTION
* Efficient, convenient and lightweight implementation.
* `PinnedConcurrentCol` is used as the underlying concurrency model.
* An unsafe counterpart of the `ConcurrentBag` which allows for collecting results concurrently while achieving a desired order of elements.
* When paired up with `ConcurrentIter`, it leads to super convenient and efficient parallel map implementations.
* Safety requirements are explicitly documented. Methods with safety requirements are marked as unsafe and requirements are explained in method docs.
* Extensive tests are defined.