### PR TITLE
concurrent-col safe drop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-ordered-bag"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient, convenient and lightweight grow-only concurrent data structure allowing high performance and ordered concurrent collection."
@@ -16,10 +16,10 @@ keywords = [
 categories = ["data-structures", "concurrency", "rust-patterns"]
 
 [dependencies]
-orx-fixed-vec = "2.9"
-orx-pinned-concurrent-col = "1.2"
-orx-pinned-vec = "2.9"
-orx-split-vec = "2.11"
+orx-fixed-vec = "2.11"
+orx-pinned-concurrent-col = "1.4"
+orx-pinned-vec = "2.11"
+orx-split-vec = "2.13"
 
 [dev-dependencies]
 orx-concurrent-iter = "1.10"

--- a/README.md
+++ b/README.md
@@ -5,36 +5,26 @@
 
 An efficient, convenient and lightweight grow-only concurrent data structure allowing high performance and ordered concurrent collection.
 
-* **convenient**: `ConcurrentBag` can safely be shared among threads simply as a shared reference. It is a [`PinnedConcurrentCol`](https://crates.io/crates/orx-pinned-concurrent-col) with a special concurrent state implementation. Underlying [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) and concurrent bag can be converted back and forth to each other. Further, as you may see in the parallel map example, it enables efficient parallel methods with possibly the most convenient and simple implementation.
-* **efficient**: `ConcurrentBag` is a lock free structure making use of a few atomic primitives, this leads to high performance concurrent growth while enabling to collect the results in the desired order.
-
-## Comparison to `ConcurrentBag`
-
-Note that [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) is a similar structure with the following differences.
-
-||`ConcurrentBag`|`ConcurrentOrderedBag`|
-|---|---|---|
-| Ordering | Cannot guarantee that the elements are in a desired order, the order of the collected elements depends on the time different threads push elements. | Allows to write to particular position enabling concurrently collecting elements in a desired order (fits very well to a parallel map). |
-| Safety of Growth | ConcurrentBag can be filled with safe `push` and `extend` calls. It makes sure that each position will be written to exactly once and there exists no race condition. | ConcurrentOrderedBag allows for more freedom by allowing to write to arbitrary positions of the collection. However, focusing on efficiency, it does not keep track of the filled positions. It is the caller's responsibility that every position is written only once and bag does not contain any gaps. Therefore, growth happens through unsafe `set_value`, `set_values` and `set_n_values` methods. However, as it will be clear in the examples that it is conveniently possible to achieve this guarantees with the help of [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter). |
-| Safety of `into_inner` | Into inner call cannot fail. Underlying pinned vector of a ConcurrentBag is always gap-free and valid; therefore, the bag can be converted into the underlying vector without care at any point in time. | Due to the above-mentioned reasons, ConcurrentOrderedBag might contain gaps. `into_inner` call provides some useful metrics such as number of elements pushed and maximum index of the vector; however, it cannot guarantee that the bag is gap-free. Therefore, the caller is required to take responsibility to unwrap the pinned vec or not through an unsafe call. |
+* **convenient**: `ConcurrentOrderedBag` can safely be shared among threads simply as a shared reference. It is a [`PinnedConcurrentCol`](https://crates.io/crates/orx-pinned-concurrent-col) with a special concurrent state implementation. Underlying [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) and concurrent bag can be converted back and forth to each other. The main goal of this collection is to enable efficient parallel operations with very simple implementations.
+* **efficient**: `ConcurrentOrderedBag` is a lock free structure suitable for concurrent, copy-free and high performance growth while enabling to collect the results in the desired order.
 
 ## Safety Requirements
 
-As the comparison reveals, `ConcurrentBag` is much safer to use than `ConcurrentOrderedBag`, which could be the first choice if the order of collected elements does not matter. On the other hand, required safety guarantees fortunately are not too difficult to satisfy. ConcurrentOrderedBag can safely be used provided that the following two conditions are satisfied:
+Unlike [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) and [`ConcurrentVec`](https://crates.io/crates/orx-concurrent-vec), collection into a `CollectionOrderedBag` is through `unsafe` setter methods which are flexible in allowing to write at any position of the bag at any order. In order to use the bag safely, the caller is expected to satisfy the following two safety requirements:
 * Each position is written exactly once, so that there exists no race condition.
-* At the point where `into_inner` is called (not necessarily always), the bag must not contain any gaps.
+* At the point where `into_inner` is called to get the underlying vector of collected elements, the bag must not contain any gaps.
   * Let `m` be the maximum index of the position that we write an element to.
   * The bag assumes that the length of the vector is equal to `m + 1`.
   * Then, it expects that exactly `m + 1` elements are written to the bag.
-  * If the first condition was satisfied; then, this condition is sufficient to conclude that the bag can be converted to the underlying vector of `m + 1` elements.
+  * If the first condition was also satisfied; then, this condition is sufficient to conclude that the bag has no gaps and can be unwrapped.
+
+Satisfying these two conditions is easy in certain situations and harder in others. A good idea in complicated cases is to pair `ConcurrentOrderedBag` with a [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter) to greatly mitigate complexity and safety risks, please see the parallel map example below.
 
 ## Examples
 
-Safety guarantees to push to the bag with a shared reference makes it easy to share the bag among threads. However, the caller is required to make sure that the collection does not contain gaps and each position is written exactly once.
-
 ### Manual Example
 
-In the following example, we split computation among two threads: the first thread processes inputs with even indices, and the second with odd indices. This provides the required guarantee mentioned above.
+In the following example, we split computation among two threads: the first thread processes inputs with even indices, and the second with odd indices. This fulfills the safety requirements mentioned above.
 
 ```rust
 use orx_concurrent_ordered_bag::*;
@@ -71,7 +61,7 @@ for i in 0..n {
 }
 ```
 
-Note that as long as no-gap and write-only-once guarantees are satisfied, `ConcurrentOrderedBag` is very flexible in the order of writes. They can simply happen in arbitrary order. Consider the following instance for instance. We spawn a thread just two write to the end of the collection, and then spawn a bunch of other threads to fill the beginning of the collection. This just works without any locks or waits.
+Note that as long as no-gap and write-only-once guarantees are satisfied, `ConcurrentOrderedBag` is very flexible in the order of writes. Consider the following example. We spawn a thread just two write to the end of the collection. Then we spawn a bunch of other threads to fill the beginning of the collection. This just works without any locks or waits.
 
 ```rust
 use orx_concurrent_ordered_bag::*;
@@ -106,11 +96,11 @@ for i in 0..(n - 1) {
 assert_eq!(vec[n - 1], 42);
 ```
 
-These examples represent cases where the work can be trivially split among threads while providing the safety requirements. However, it requires special care and correctness. This complexity can significantly be avoided by pairing the `ConcurrentOrderedBag` with a [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter) on the input side.
+These examples represent cases where the work can be trivially split among threads while providing the safety requirements. In a general case, it requires special care to fulfill the safety requirements. This complexity and safety risks can significantly be avoided by pairing the `ConcurrentOrderedBag` with a [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter) on the input side.
 
 ### Parallel Map with `ConcurrentIter`
 
-Parallel map operation is one of the cases where we would care about the order of the collected elements, and hence, `ConcurrentBag` would not suffice. On the other hand, an efficient implementation can be achieved with `ConcurrentOrderedBag` and `ConcurrentIter`. Further, it might **possibly be the most convenient parallel map** implementation that is almost identical to a single-threaded map implementation.
+Parallel map operation is one of the cases where we care about the order of the collected elements, and hence, a `ConcurrentBag` would not do. On the other hand, a very simple yet efficient implementation can be achieved with `ConcurrentOrderedBag` and `ConcurrentIter`.
 
 ```rust
 use orx_concurrent_ordered_bag::*;
@@ -142,19 +132,18 @@ where
 }
 
 let len = 2465;
-let vec: Vec<_> = (0..len).map(|x| x.to_string()).collect();
+let input: Vec<_> = (0..len).map(|x| x.to_string()).collect();
 
-let bag = parallel_map(4, vec.into_con_iter(), &|x| x.to_string().len());
+let bag = parallel_map(4, input.into_con_iter(), &|x| x.to_string().len());
+
 let output = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
-
 assert_eq!(output.len(), len);
 for (i, value) in output.iter().enumerate() {
     assert_eq!(value, &i.to_string().len());
 }
 ```
 
-As you may see, we are not required to share the work manually, we simply use a `while let Some` loop. The work is pulled by threads from the iterator. This both leads to an efficient implementation especially in cases of heterogeneous work loads of each task and automatically provides the safety requirements.
-
+As you may see, no manual work or care is required to satisfy the safety requirements. Each element of the iterator is processed and written exactly once, just as it would in a sequential implementation.
 
 ### Parallel Map with `ExactSizeConcurrentIter`
 
@@ -191,8 +180,9 @@ where
 }
 
 let len = 2465;
-let vec: Vec<_> = (0..len).map(|x| x.to_string()).collect();
-let bag = parallel_map(4, vec.into_con_iter(), &|x| x.to_string().len(), 64);
+let input: Vec<_> = (0..len).map(|x| x.to_string()).collect();
+let bag = parallel_map(4, input.into_con_iter(), &|x| x.to_string().len(), 64);
+
 let output = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
 for (i, value) in output.iter().enumerate() {
     assert_eq!(value, &i.to_string().len());
@@ -247,6 +237,17 @@ The concurrent state is modeled simply by an atomic capacity. Combination of thi
 * Only one growth can happen at a given time.
 * Reading is only possible after converting the bag into the underlying `PinnedVec`.
 * ⟹ no read & write race condition exists.
+
+## Concurrent Friend Collections
+
+||[`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag)|[`ConcurrentVec`](https://crates.io/crates/orx-concurrent-vec)|[`ConcurrentOrderedBag`](https://crates.io/crates/orx-concurrent-ordered-bag)|
+|---|---|---|---|
+| Underlying Storage | Directly in a `PinnedVec<T>` | Elements are wrapped with optional; i.e., stored in a `PinnedVec<Option<T>>` | Directly in a `PinnedVec<T>` |
+| Write | Guarantees that each element is written exactly once via `push` or `extend` methods | Guarantees that each element is written exactly once via `push` or `extend` methods | Different in two ways. First, a position can be written multiple times. Second, an arbitrary element of the bag can be written at any time at any order using `set_value` and `set_values` methods. This provides a great flexibility while moving the safety responsibility to the caller; hence, the set methods are `unsafe`. |
+| Read | Mainly, a write-only collection. Concurrent reading of already pushed elements is through `unsafe` `get` and `iter` methods. The caller is required to avoid race conditions. | A write-and-read collection. Already pushed elements can safely be read through `get` and `iter` methods. | Not supported currently. Due to the flexible but unsafe nature of write operations, it is difficult to provide required safety guarantees as a caller. |
+| Ordering of Elements | Since write operations are through adding elements to the end of the pinned vector via `push` and `extend`, two multi-threaded executions of a code that collects elements into the bag might result in the elements being collected in different orders. | Since write operations are through adding elements to the end of the pinned vector via `push` and `extend`, two multi-threaded executions of a code that collects elements into the bag might result in the elements being collected in different orders. | This is the main goal of this collection, allowing to collect elements concurrently and in the correct order. Although this does not seem trivial; it can be achieved almost trivially when `ConcurrentOrderedBag` is used together with a [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter). |
+| `into_inner` | Once the concurrent collection is completed, the bag can safely be converted to its underlying `PinnedVec<T>` without a cost. | Once the concurrent collection is completed, the bag can safely be converted to its underlying `PinnedVec<Option<T>>` of option-wrapped elements without a cost. | Growing through flexible setters allowing to write to any position, `ConcurrentOrderedBag` has the risk of containing gaps. `into_inner` call provides some useful metrics such as whether the number of elements pushed elements match the  maximum index of the vector; however, it cannot guarantee that the bag is gap-free. The caller is required to take responsibility to unwrap to get the underlying `PinnedVec<T>` through an `unsafe` call. |
+|||||
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,36 +5,26 @@
 //!
 //! An efficient, convenient and lightweight grow-only concurrent data structure allowing high performance and ordered concurrent collection.
 //!
-//! * **convenient**: `ConcurrentBag` can safely be shared among threads simply as a shared reference. It is a [`PinnedConcurrentCol`](https://crates.io/crates/orx-pinned-concurrent-col) with a special concurrent state implementation. Underlying [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) and concurrent bag can be converted back and forth to each other. Further, as you may see in the parallel map example, it enables efficient parallel methods with possibly the most convenient and simple implementation.
-//! * **efficient**: `ConcurrentBag` is a lock free structure making use of a few atomic primitives, this leads to high performance concurrent growth while enabling to collect the results in the desired order.
-//!
-//! ## Comparison to `ConcurrentBag`
-//!
-//! Note that [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) is a similar structure with the following differences.
-//!
-//! ||`ConcurrentBag`|`ConcurrentOrderedBag`|
-//! |---|---|---|
-//! | Ordering | Cannot guarantee that the elements are in a desired order, the order of the collected elements depends on the time different threads push elements. | Allows to write to particular position enabling concurrently collecting elements in a desired order (fits very well to a parallel map). |
-//! | Safety of Growth | ConcurrentBag can be filled with safe `push` and `extend` calls. It makes sure that each position will be written to exactly once and there exists no race condition. | ConcurrentOrderedBag allows for more freedom by allowing to write to arbitrary positions of the collection. However, focusing on efficiency, it does not keep track of the filled positions. It is the caller's responsibility that every position is written only once and bag does not contain any gaps. Therefore, growth happens through unsafe `set_value`, `set_values` and `set_n_values` methods. However, as it will be clear in the examples that it is conveniently possible to achieve this guarantees with the help of [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter). |
-//! | Safety of `into_inner` | Into inner call cannot fail. Underlying pinned vector of a ConcurrentBag is always gap-free and valid; therefore, the bag can be converted into the underlying vector without care at any point in time. | Due to the above-mentioned reasons, ConcurrentOrderedBag might contain gaps. `into_inner` call provides some useful metrics such as number of elements pushed and maximum index of the vector; however, it cannot guarantee that the bag is gap-free. Therefore, the caller is required to take responsibility to unwrap the pinned vec or not through an unsafe call. |
+//! * **convenient**: `ConcurrentOrderedBag` can safely be shared among threads simply as a shared reference. It is a [`PinnedConcurrentCol`](https://crates.io/crates/orx-pinned-concurrent-col) with a special concurrent state implementation. Underlying [`PinnedVec`](https://crates.io/crates/orx-pinned-vec) and concurrent bag can be converted back and forth to each other. The main goal of this collection is to enable efficient parallel operations with very simple implementations.
+//! * **efficient**: `ConcurrentOrderedBag` is a lock free structure suitable for concurrent, copy-free and high performance growth while enabling to collect the results in the desired order.
 //!
 //! ## Safety Requirements
 //!
-//! As the comparison reveals, `ConcurrentBag` is much safer to use than `ConcurrentOrderedBag`, which could be the first choice if the order of collected elements does not matter. On the other hand, required safety guarantees fortunately are not too difficult to satisfy. ConcurrentOrderedBag can safely be used provided that the following two conditions are satisfied:
+//! Unlike [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) and [`ConcurrentVec`](https://crates.io/crates/orx-concurrent-vec), collection into a `CollectionOrderedBag` is through `unsafe` setter methods which are flexible in allowing to write at any position of the bag at any order. In order to use the bag safely, the caller is expected to satisfy the following two safety requirements:
 //! * Each position is written exactly once, so that there exists no race condition.
-//! * At the point where `into_inner` is called (not necessarily always), the bag must not contain any gaps.
+//! * At the point where `into_inner` is called to get the underlying vector of collected elements, the bag must not contain any gaps.
 //!   * Let `m` be the maximum index of the position that we write an element to.
 //!   * The bag assumes that the length of the vector is equal to `m + 1`.
 //!   * Then, it expects that exactly `m + 1` elements are written to the bag.
-//!   * If the first condition was satisfied; then, this condition is sufficient to conclude that the bag can be converted to the underlying vector of `m + 1` elements.
+//!   * If the first condition was also satisfied; then, this condition is sufficient to conclude that the bag has no gaps and can be unwrapped.
+//!
+//! Satisfying these two conditions is easy in certain situations and harder in others. A good idea in complicated cases is to pair `ConcurrentOrderedBag` with a [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter) to greatly mitigate complexity and safety risks, please see the parallel map example below.
 //!
 //! ## Examples
 //!
-//! Safety guarantees to push to the bag with a shared reference makes it easy to share the bag among threads. However, the caller is required to make sure that the collection does not contain gaps and each position is written exactly once.
-//!
 //! ### Manual Example
 //!
-//! In the following example, we split computation among two threads: the first thread processes inputs with even indices, and the second with odd indices. This provides the required guarantee mentioned above.
+//! In the following example, we split computation among two threads: the first thread processes inputs with even indices, and the second with odd indices. This fulfills the safety requirements mentioned above.
 //!
 //! ```rust
 //! use orx_concurrent_ordered_bag::*;
@@ -71,7 +61,7 @@
 //! }
 //! ```
 //!
-//! Note that as long as no-gap and write-only-once guarantees are satisfied, `ConcurrentOrderedBag` is very flexible in the order of writes. They can simply happen in arbitrary order. Consider the following instance for instance. We spawn a thread just two write to the end of the collection, and then spawn a bunch of other threads to fill the beginning of the collection. This just works without any locks or waits.
+//! Note that as long as no-gap and write-only-once guarantees are satisfied, `ConcurrentOrderedBag` is very flexible in the order of writes. Consider the following example. We spawn a thread just two write to the end of the collection. Then we spawn a bunch of other threads to fill the beginning of the collection. This just works without any locks or waits.
 //!
 //! ```rust
 //! use orx_concurrent_ordered_bag::*;
@@ -106,11 +96,11 @@
 //! assert_eq!(vec[n - 1], 42);
 //! ```
 //!
-//! These examples represent cases where the work can be trivially split among threads while providing the safety requirements. However, it requires special care and correctness. This complexity can significantly be avoided by pairing the `ConcurrentOrderedBag` with a [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter) on the input side.
+//! These examples represent cases where the work can be trivially split among threads while providing the safety requirements. In a general case, it requires special care to fulfill the safety requirements. This complexity and safety risks can significantly be avoided by pairing the `ConcurrentOrderedBag` with a [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter) on the input side.
 //!
 //! ### Parallel Map with `ConcurrentIter`
 //!
-//! Parallel map operation is one of the cases where we would care about the order of the collected elements, and hence, `ConcurrentBag` would not suffice. On the other hand, an efficient implementation can be achieved with `ConcurrentOrderedBag` and `ConcurrentIter`. Further, it might **possibly be the most convenient parallel map** implementation that is almost identical to a single-threaded map implementation.
+//! Parallel map operation is one of the cases where we care about the order of the collected elements, and hence, a `ConcurrentBag` would not do. On the other hand, a very simple yet efficient implementation can be achieved with `ConcurrentOrderedBag` and `ConcurrentIter`.
 //!
 //! ```rust
 //! use orx_concurrent_ordered_bag::*;
@@ -142,19 +132,18 @@
 //! }
 //!
 //! let len = 2465;
-//! let vec: Vec<_> = (0..len).map(|x| x.to_string()).collect();
+//! let input: Vec<_> = (0..len).map(|x| x.to_string()).collect();
 //!
-//! let bag = parallel_map(4, vec.into_con_iter(), &|x| x.to_string().len());
+//! let bag = parallel_map(4, input.into_con_iter(), &|x| x.to_string().len());
+//!
 //! let output = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
-//!
 //! assert_eq!(output.len(), len);
 //! for (i, value) in output.iter().enumerate() {
 //!     assert_eq!(value, &i.to_string().len());
 //! }
 //! ```
 //!
-//! As you may see, we are not required to share the work manually, we simply use a `while let Some` loop. The work is pulled by threads from the iterator. This both leads to an efficient implementation especially in cases of heterogeneous work loads of each task and automatically provides the safety requirements.
-//!
+//! As you may see, no manual work or care is required to satisfy the safety requirements. Each element of the iterator is processed and written exactly once, just as it would in a sequential implementation.
 //!
 //! ### Parallel Map with `ExactSizeConcurrentIter`
 //!
@@ -191,8 +180,9 @@
 //! }
 //!
 //! let len = 2465;
-//! let vec: Vec<_> = (0..len).map(|x| x.to_string()).collect();
-//! let bag = parallel_map(4, vec.into_con_iter(), &|x| x.to_string().len(), 64);
+//! let input: Vec<_> = (0..len).map(|x| x.to_string()).collect();
+//! let bag = parallel_map(4, input.into_con_iter(), &|x| x.to_string().len(), 64);
+//!
 //! let output = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
 //! for (i, value) in output.iter().enumerate() {
 //!     assert_eq!(value, &i.to_string().len());
@@ -247,6 +237,17 @@
 //! * Only one growth can happen at a given time.
 //! * Reading is only possible after converting the bag into the underlying `PinnedVec`.
 //! * ⟹ no read & write race condition exists.
+//!
+//! ## Concurrent Friend Collections
+//!
+//! ||[`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag)|[`ConcurrentVec`](https://crates.io/crates/orx-concurrent-vec)|[`ConcurrentOrderedBag`](https://crates.io/crates/orx-concurrent-ordered-bag)|
+//! |---|---|---|---|
+//! | Underlying Storage | Directly in a `PinnedVec<T>` | Elements are wrapped with optional; i.e., stored in a `PinnedVec<Option<T>>` | Directly in a `PinnedVec<T>` |
+//! | Write | Guarantees that each element is written exactly once via `push` or `extend` methods | Guarantees that each element is written exactly once via `push` or `extend` methods | Different in two ways. First, a position can be written multiple times. Second, an arbitrary element of the bag can be written at any time at any order using `set_value` and `set_values` methods. This provides a great flexibility while moving the safety responsibility to the caller; hence, the set methods are `unsafe`. |
+//! | Read | Mainly, a write-only collection. Concurrent reading of already pushed elements is through `unsafe` `get` and `iter` methods. The caller is required to avoid race conditions. | A write-and-read collection. Already pushed elements can safely be read through `get` and `iter` methods. | Not supported currently. Due to the flexible but unsafe nature of write operations, it is difficult to provide required safety guarantees as a caller. |
+//! | Ordering of Elements | Since write operations are through adding elements to the end of the pinned vector via `push` and `extend`, two multi-threaded executions of a code that collects elements into the bag might result in the elements being collected in different orders. | Since write operations are through adding elements to the end of the pinned vector via `push` and `extend`, two multi-threaded executions of a code that collects elements into the bag might result in the elements being collected in different orders. | This is the main goal of this collection, allowing to collect elements concurrently and in the correct order. Although this does not seem trivial; it can be achieved almost trivially when `ConcurrentOrderedBag` is used together with a [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter). |
+//! | `into_inner` | Once the concurrent collection is completed, the bag can safely be converted to its underlying `PinnedVec<T>` without a cost. | Once the concurrent collection is completed, the bag can safely be converted to its underlying `PinnedVec<Option<T>>` of option-wrapped elements without a cost. | Growing through flexible setters allowing to write to any position, `ConcurrentOrderedBag` has the risk of containing gaps. `into_inner` call provides some useful metrics such as whether the number of elements pushed elements match the  maximum index of the vector; however, it cannot guarantee that the bag is gap-free. The caller is required to take responsibility to unwrap to get the underlying `PinnedVec<T>` through an `unsafe` call. |
+//! |||||
 //!
 //! ## License
 //!

--- a/src/new.rs
+++ b/src/new.rs
@@ -36,7 +36,7 @@ impl<T> ConcurrentOrderedBag<T, SplitVec<T, Linear>> {
     ///
     /// This leads to a [`orx_pinned_concurrent_col::PinnedConcurrentCol::maximum_capacity`] of `fragments_capacity * 2 ^ constant_fragment_capacity_exponent`.
     ///
-    /// Whenever this capacity is not sufficient, fragments capacity can be increased by using the  [`orx_pinned_concurrent_col::PinnedConcurrentCol::reserve_maximum_capacity`] method.    
+    /// Whenever this capacity is not sufficient, fragments capacity can be increased by using the  [`orx_pinned_concurrent_col::PinnedConcurrentCol::reserve_maximum_capacity`] method.
     pub fn with_linear_growth(
         constant_fragment_capacity_exponent: usize,
         fragments_capacity: usize,

--- a/tests/drop.rs
+++ b/tests/drop.rs
@@ -1,0 +1,67 @@
+use orx_concurrent_ordered_bag::*;
+use test_case::test_matrix;
+
+const NUM_RERUNS: usize = 1024;
+
+#[test_matrix(
+    [
+        FixedVec::new(100000),
+        SplitVec::with_doubling_growth_and_fragments_capacity(32),
+        SplitVec::with_recursive_growth_and_fragments_capacity(32),
+        SplitVec::with_linear_growth_and_fragments_capacity(10, 64),
+    ],
+    [124, 348, 1024, 2587, 42578]
+)]
+fn dropped_as_bag<P: PinnedVec<String> + Clone>(pinned_vec: P, len: usize) {
+    for _ in 0..NUM_RERUNS {
+        let num_threads = 4;
+        let num_items_per_thread = len / num_threads;
+
+        let bag = fill_bag(pinned_vec.clone(), len);
+
+        assert_eq!(bag.len(), num_threads * num_items_per_thread);
+    }
+}
+
+#[test_matrix(
+    [
+        FixedVec::new(100000),
+        SplitVec::with_doubling_growth_and_fragments_capacity(32),
+        SplitVec::with_recursive_growth_and_fragments_capacity(32),
+        SplitVec::with_linear_growth_and_fragments_capacity(10, 64),
+    ],
+    [124, 348, 1024, 2587, 42578]
+)]
+fn dropped_after_into_inner<P: PinnedVec<String> + Clone>(pinned_vec: P, len: usize) {
+    for _ in 0..NUM_RERUNS {
+        let num_threads = 4;
+        let num_items_per_thread = len / num_threads;
+
+        let bag = fill_bag(pinned_vec.clone(), len);
+
+        let inner = unsafe { bag.into_inner().unwrap_only_if_counts_match() };
+        assert_eq!(inner.len(), num_threads * num_items_per_thread);
+    }
+}
+
+fn fill_bag<P: PinnedVec<String>>(pinned_vec: P, len: usize) -> ConcurrentOrderedBag<String, P> {
+    let num_threads = 4;
+    let num_items_per_thread = len / num_threads;
+
+    let bag: ConcurrentOrderedBag<_, _> = pinned_vec.into();
+    let con_bag = &bag;
+    std::thread::scope(move |s| {
+        for i in 0..num_threads {
+            s.spawn(move || {
+                let mut idx = i * num_items_per_thread;
+                for value in 0..num_items_per_thread {
+                    let new_value = format!("from-thread-{}", value);
+                    unsafe { con_bag.set_value(idx, new_value) };
+                    idx += 1;
+                }
+            });
+        }
+    });
+
+    bag
+}


### PR DESCRIPTION
* Upgraded to new version of `PinnedConcurrentCol` with additional drop safety.
* `State::try_get_no_gap_len` is implemented.
* Drop tests are extended.
* Documentation is revised.