### PR TITLE
Internal State revision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-ordered-bag"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient, convenient and lightweight grow-only concurrent data structure allowing high performance and ordered concurrent collection."
@@ -16,11 +16,11 @@ keywords = [
 categories = ["data-structures", "concurrency", "rust-patterns"]
 
 [dependencies]
-orx-pseudo-default = "1.2.0"
-orx-pinned-vec = "3.2.0"
-orx-fixed-vec = "3.2.0"
-orx-split-vec = "3.2.0"
-orx-pinned-concurrent-col = "2.2.0"
+orx-pseudo-default = "1.2"
+orx-pinned-vec = "3.3"
+orx-fixed-vec = "3.3"
+orx-split-vec = "3.3"
+orx-pinned-concurrent-col = "2.3"
 
 [dev-dependencies]
 orx-concurrent-iter = "1.22"

--- a/README.md
+++ b/README.md
@@ -189,45 +189,6 @@ for (i, value) in output.iter().enumerate() {
 }
 ```
 
-### Construction
-
-`ConcurrentOrderedBag` can be constructed by wrapping any pinned vector; i.e., `ConcurrentOrderedBag<T>` implements `From<P: PinnedVec<T>>`. Likewise, a concurrent vector can be unwrapped without any allocation to the underlying pinned vector with `into_inner` method, provided that the safety requirements are satisfied.
-
-Further, there exist `with_` methods to directly construct the concurrent bag with common pinned vector implementations.
-
-```rust
-use orx_concurrent_ordered_bag::*;
-
-// default pinned vector -> SplitVec<T, Doubling>
-let bag: ConcurrentOrderedBag<char> = ConcurrentOrderedBag::new();
-let bag: ConcurrentOrderedBag<char> = Default::default();
-let bag: ConcurrentOrderedBag<char> = ConcurrentOrderedBag::with_doubling_growth();
-let bag: ConcurrentOrderedBag<char, SplitVec<char, Doubling>> = ConcurrentOrderedBag::with_doubling_growth();
-
-let bag: ConcurrentOrderedBag<char> = SplitVec::new().into();
-let bag: ConcurrentOrderedBag<char, SplitVec<char, Doubling>> = SplitVec::new().into();
-
-// SplitVec with [Linear](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Linear.html) growth
-// each fragment will have capacity 2^10 = 1024
-// and the split vector can grow up to 32 fragments
-let bag: ConcurrentOrderedBag<char, SplitVec<char, Linear>> = ConcurrentOrderedBag::with_linear_growth(10, 32);
-let bag: ConcurrentOrderedBag<char, SplitVec<char, Linear>> = SplitVec::with_linear_growth_and_fragments_capacity(10, 32).into();
-
-// [FixedVec](https://docs.rs/orx-fixed-vec/latest/orx_fixed_vec/) with fixed capacity.
-// Fixed vector cannot grow; hence, pushing the 1025-th element to this bag will cause a panic!
-let bag: ConcurrentOrderedBag<char, FixedVec<char>> = ConcurrentOrderedBag::with_fixed_capacity(1024);
-let bag: ConcurrentOrderedBag<char, FixedVec<char>> = FixedVec::new(1024).into();
-```
-
-Of course, the pinned vector to be wrapped does not need to be empty.
-
-```rust
-use orx_concurrent_ordered_bag::*;
-
-let split_vec: SplitVec<i32> = (0..1024).collect();
-let bag: ConcurrentOrderedBag<_> = split_vec.into();
-```
-
 ## Concurrent State and Properties
 
 The concurrent state is modeled simply by an atomic capacity. Combination of this state and `PinnedConcurrentCol` leads to the following properties:
@@ -245,7 +206,7 @@ The concurrent state is modeled simply by an atomic capacity. Combination of thi
 | Write | Guarantees that each element is written exactly once via `push` or `extend` methods | Guarantees that each element is written exactly once via `push` or `extend` methods | Different in two ways. First, a position can be written multiple times. Second, an arbitrary element of the bag can be written at any time at any order using `set_value` and `set_values` methods. This provides a great flexibility while moving the safety responsibility to the caller; hence, the set methods are `unsafe`. |
 | Read | Mainly, a write-only collection. Concurrent reading of already pushed elements is through `unsafe` `get` and `iter` methods. The caller is required to avoid race conditions. | A write-and-read collection. Already pushed elements can safely be read through `get` and `iter` methods. | Not supported currently. Due to the flexible but unsafe nature of write operations, it is difficult to provide required safety guarantees as a caller. |
 | Ordering of Elements | Since write operations are through adding elements to the end of the pinned vector via `push` and `extend`, two multi-threaded executions of a code that collects elements into the bag might result in the elements being collected in different orders. | Since write operations are through adding elements to the end of the pinned vector via `push` and `extend`, two multi-threaded executions of a code that collects elements into the bag might result in the elements being collected in different orders. | This is the main goal of this collection, allowing to collect elements concurrently and in the correct order. Although this does not seem trivial; it can be achieved almost trivially when `ConcurrentOrderedBag` is used together with a [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter). |
-| `into_inner` | Once the concurrent collection is completed, the bag can safely be converted to its underlying `PinnedVec<T>`. | Once the concurrent collection is completed, the bag can safely be converted to its underlying `PinnedVec<T>`. | Growing through flexible setters allowing to write to any position, `ConcurrentOrderedBag` has the risk of containing gaps. `into_inner` call provides some useful metrics such as whether the number of elements pushed elements match the  maximum index of the vector; however, it cannot guarantee that the bag is gap-free. The caller is required to take responsibility to unwrap to get the underlying `PinnedVec<T>` through an `unsafe` call. |
+| `into_inner` | Once the concurrent collection is completed, the bag can safely and cheaply be converted to its underlying `PinnedVec<T>`. | Once the concurrent collection is completed, the vec can safely be converted to its underlying `PinnedVec<ConcurrentOption<T>>`. Notice that elements are wrapped with a `ConcurrentOption` in order to provide thread safe concurrent read & write operations. | Growing through flexible setters allowing to write to any position, `ConcurrentOrderedBag` has the risk of containing gaps. `into_inner` call provides some useful metrics such as whether the number of elements pushed elements match the  maximum index of the vector; however, it cannot guarantee that the bag is gap-free. The caller is required to take responsibility to unwrap to get the underlying `PinnedVec<T>` through an `unsafe` call. |
 |||||
 
 ## License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,45 +189,6 @@
 //! }
 //! ```
 //!
-//! ### Construction
-//!
-//! `ConcurrentOrderedBag` can be constructed by wrapping any pinned vector; i.e., `ConcurrentOrderedBag<T>` implements `From<P: PinnedVec<T>>`. Likewise, a concurrent vector can be unwrapped without any allocation to the underlying pinned vector with `into_inner` method, provided that the safety requirements are satisfied.
-//!
-//! Further, there exist `with_` methods to directly construct the concurrent bag with common pinned vector implementations.
-//!
-//! ```rust
-//! use orx_concurrent_ordered_bag::*;
-//!
-//! // default pinned vector -> SplitVec<T, Doubling>
-//! let bag: ConcurrentOrderedBag<char> = ConcurrentOrderedBag::new();
-//! let bag: ConcurrentOrderedBag<char> = Default::default();
-//! let bag: ConcurrentOrderedBag<char> = ConcurrentOrderedBag::with_doubling_growth();
-//! let bag: ConcurrentOrderedBag<char, SplitVec<char, Doubling>> = ConcurrentOrderedBag::with_doubling_growth();
-//!
-//! let bag: ConcurrentOrderedBag<char> = SplitVec::new().into();
-//! let bag: ConcurrentOrderedBag<char, SplitVec<char, Doubling>> = SplitVec::new().into();
-//!
-//! // SplitVec with [Linear](https://docs.rs/orx-split-vec/latest/orx_split_vec/struct.Linear.html) growth
-//! // each fragment will have capacity 2^10 = 1024
-//! // and the split vector can grow up to 32 fragments
-//! let bag: ConcurrentOrderedBag<char, SplitVec<char, Linear>> = ConcurrentOrderedBag::with_linear_growth(10, 32);
-//! let bag: ConcurrentOrderedBag<char, SplitVec<char, Linear>> = SplitVec::with_linear_growth_and_fragments_capacity(10, 32).into();
-//!
-//! // [FixedVec](https://docs.rs/orx-fixed-vec/latest/orx_fixed_vec/) with fixed capacity.
-//! // Fixed vector cannot grow; hence, pushing the 1025-th element to this bag will cause a panic!
-//! let bag: ConcurrentOrderedBag<char, FixedVec<char>> = ConcurrentOrderedBag::with_fixed_capacity(1024);
-//! let bag: ConcurrentOrderedBag<char, FixedVec<char>> = FixedVec::new(1024).into();
-//! ```
-//!
-//! Of course, the pinned vector to be wrapped does not need to be empty.
-//!
-//! ```rust
-//! use orx_concurrent_ordered_bag::*;
-//!
-//! let split_vec: SplitVec<i32> = (0..1024).collect();
-//! let bag: ConcurrentOrderedBag<_> = split_vec.into();
-//! ```
-//!
 //! ## Concurrent State and Properties
 //!
 //! The concurrent state is modeled simply by an atomic capacity. Combination of this state and `PinnedConcurrentCol` leads to the following properties:
@@ -245,7 +206,7 @@
 //! | Write | Guarantees that each element is written exactly once via `push` or `extend` methods | Guarantees that each element is written exactly once via `push` or `extend` methods | Different in two ways. First, a position can be written multiple times. Second, an arbitrary element of the bag can be written at any time at any order using `set_value` and `set_values` methods. This provides a great flexibility while moving the safety responsibility to the caller; hence, the set methods are `unsafe`. |
 //! | Read | Mainly, a write-only collection. Concurrent reading of already pushed elements is through `unsafe` `get` and `iter` methods. The caller is required to avoid race conditions. | A write-and-read collection. Already pushed elements can safely be read through `get` and `iter` methods. | Not supported currently. Due to the flexible but unsafe nature of write operations, it is difficult to provide required safety guarantees as a caller. |
 //! | Ordering of Elements | Since write operations are through adding elements to the end of the pinned vector via `push` and `extend`, two multi-threaded executions of a code that collects elements into the bag might result in the elements being collected in different orders. | Since write operations are through adding elements to the end of the pinned vector via `push` and `extend`, two multi-threaded executions of a code that collects elements into the bag might result in the elements being collected in different orders. | This is the main goal of this collection, allowing to collect elements concurrently and in the correct order. Although this does not seem trivial; it can be achieved almost trivially when `ConcurrentOrderedBag` is used together with a [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter). |
-//! | `into_inner` | Once the concurrent collection is completed, the bag can safely be converted to its underlying `PinnedVec<T>`. | Once the concurrent collection is completed, the bag can safely be converted to its underlying `PinnedVec<T>`. | Growing through flexible setters allowing to write to any position, `ConcurrentOrderedBag` has the risk of containing gaps. `into_inner` call provides some useful metrics such as whether the number of elements pushed elements match the  maximum index of the vector; however, it cannot guarantee that the bag is gap-free. The caller is required to take responsibility to unwrap to get the underlying `PinnedVec<T>` through an `unsafe` call. |
+//! | `into_inner` | Once the concurrent collection is completed, the bag can safely and cheaply be converted to its underlying `PinnedVec<T>`. | Once the concurrent collection is completed, the vec can safely be converted to its underlying `PinnedVec<ConcurrentOption<T>>`. Notice that elements are wrapped with a `ConcurrentOption` in order to provide thread safe concurrent read & write operations. | Growing through flexible setters allowing to write to any position, `ConcurrentOrderedBag` has the risk of containing gaps. `into_inner` call provides some useful metrics such as whether the number of elements pushed elements match the  maximum index of the vector; however, it cannot guarantee that the bag is gap-free. The caller is required to take responsibility to unwrap to get the underlying `PinnedVec<T>` through an `unsafe` call. |
 //! |||||
 //!
 //! ## License

--- a/src/state.rs
+++ b/src/state.rs
@@ -8,12 +8,12 @@ pub struct ConcurrentOrderedBagState {
     num_pushed: AtomicUsize,
 }
 
-impl ConcurrentState for ConcurrentOrderedBagState {
-    fn zero_memory(&self) -> bool {
-        false
+impl<T> ConcurrentState<T> for ConcurrentOrderedBagState {
+    fn fill_memory_with(&self) -> Option<fn() -> T> {
+        None
     }
 
-    fn new_for_pinned_vec<T, P: PinnedVec<T>>(pinned_vec: &P) -> Self {
+    fn new_for_pinned_vec<P: PinnedVec<T>>(pinned_vec: &P) -> Self {
         Self {
             is_growing: false.into(),
             len: pinned_vec.len().into(),
@@ -21,7 +21,7 @@ impl ConcurrentState for ConcurrentOrderedBagState {
         }
     }
 
-    fn new_for_con_pinned_vec<T, P: ConcurrentPinnedVec<T>>(_: &P, len: usize) -> Self {
+    fn new_for_con_pinned_vec<P: ConcurrentPinnedVec<T>>(_: &P, len: usize) -> Self {
         Self {
             is_growing: false.into(),
             len: len.into(),
@@ -29,10 +29,9 @@ impl ConcurrentState for ConcurrentOrderedBagState {
         }
     }
 
-    fn write_permit<T, P, S>(&self, col: &PinnedConcurrentCol<T, P, S>, idx: usize) -> WritePermit
+    fn write_permit<P>(&self, col: &PinnedConcurrentCol<T, P, Self>, idx: usize) -> WritePermit
     where
         P: ConcurrentPinnedVec<T>,
-        S: ConcurrentState,
     {
         match idx.cmp(&col.capacity()) {
             std::cmp::Ordering::Less => WritePermit::JustWrite,


### PR DESCRIPTION
Internal `State` is revised to match with the changes in pinned concurrent collections to enable data structures which always have an initialized and valid state.