### PR TITLE
revise trait bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-ordered-bag"
-version = "2.14.0"
+version = "3.0.0"
 edition = "2024"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient, convenient and lightweight grow-only concurrent data structure allowing high performance and ordered concurrent collection."


### PR DESCRIPTION
Revise send & sync trait bound requirements:

* `ConcurrentOrderedBag` does not have a global trait bound on its item type in order to allow it to be used for multiple purposes.
* Methods which adds elements to the bag, such as `set_value` or `set_values` require item type to be `Send`.
* Methods which mutate elements by using a `&mut self` reference do not have any bounds since it must be an exclusive reference to the bag.


Fixes #21